### PR TITLE
Manual fix needed: pve-qemu deb build failed

### DIFF
--- a/patch-failures/pve-qemu/debian/control.rej
+++ b/patch-failures/pve-qemu/debian/control.rej
@@ -1,0 +1,10 @@
+--- debian/control
++++ debian/control
+@@ -50,6 +50,7 @@ Depends: ceph-common (>= 0.48),
+          iproute2,
+          libiscsi4 (>= 1.12.0) | libiscsi7,
+          libjpeg62-turbo,
++         pve-edk2-firmware-aarch64,
+          libspice-server1 (>= 0.14.0~),
+          libusb-1.0-0 (>= 1.0.17-1),
+          libusbredirparser1 (>= 0.6-2),


### PR DESCRIPTION
The debian package build failed during the check-patches workflow.

**Failed packages:**
- pve-qemu

**Failed workflow run:** https://github.com/hwinther/wsh-pve/actions/runs/25366763311

Please investigate and push fixes to this branch. Once the build succeeds, merge this PR.

**Rejected hunks (.rej files)** are included in the `patch-failures/` directory for reference.