### PR TITLE
Manual fix needed: deb build failed (patch trigger)

### DIFF
--- a/patch-failures/pve-qemu/debian/control.rej
+++ b/patch-failures/pve-qemu/debian/control.rej
@@ -1,0 +1,10 @@
+--- debian/control
++++ debian/control
+@@ -50,6 +50,7 @@ Depends: ceph-common (>= 0.48),
+          iproute2,
+          libiscsi4 (>= 1.12.0) | libiscsi7,
+          libjpeg62-turbo,
++         pve-edk2-firmware-aarch64,
+          libspice-server1 (>= 0.14.0~),
+          libusb-1.0-0 (>= 1.0.17-1),
+          libusbredirparser1 (>= 0.6-2),

--- a/patch-failures/qemu-server/src/PVE/QemuServer.pm.rej
+++ b/patch-failures/qemu-server/src/PVE/QemuServer.pm.rej
@@ -1,0 +1,18 @@
+--- src/PVE/QemuServer.pm
++++ src/PVE/QemuServer.pm
+@@ -3279,9 +3335,13 @@ sub config_to_command {
+                 $value =~ s/,/,,/g;
+                 $smbios_string .= "," . $key . "=" . $value if $value;
+             }
+-            push @$cmd, '-smbios', "type=1" . $smbios_string;
++            if ($arch !~ m/^sparc/) {
++                push @$cmd, '-smbios', "type=1" . $smbios_string;
++            }
+         } else {
+-            push @$cmd, '-smbios', "type=1,$conf->{smbios1}";
++            if ($arch !~ m/^sparc/) {
++                push @$cmd, '-smbios', "type=1,$conf->{smbios1}";
++            }
+         }
+     }
+ 


### PR DESCRIPTION
The debian package build failed during the check-patches workflow.

**Failed packages:**
- qemu-server
- pve-qemu

**Failed workflow run:** https://github.com/hwinther/wsh-pve/actions/runs/25486182709

Please investigate and push fixes to this branch. Once the build succeeds, merge this PR.

**Rejected hunks (.rej files)** are included in the `patch-failures/` directory for reference.