### PR TITLE
Manual fix needed: pve-qemu deb build failed

### DIFF
--- a/patch-failures/pve-qemu/debian/rules.rej
+++ b/patch-failures/pve-qemu/debian/rules.rej
@@ -1,0 +1,43 @@
+--- debian/rules
++++ debian/rules
+@@ -124,12 +126,40 @@ install: build
+ 	rm -f $(destdir)/usr/lib/kvm/qemu-bridge-helper
+ 	rm -f $(destdir)/usr/lib/kvm/virtfs-proxy-helper
+ 
++# Add extra binaries, sparc backport and 3dfx passthrough
++ifneq ("$(wildcard ../../../build/pve-qemu-7.2-sparc/qemu-system-sparc)", "")
++	cp ../../../build/pve-qemu-7.2-sparc/qemu-system-sparc $(destdir)/usr/bin/qemu-system-sparc-7.2
++endif
++
++ifneq ("$(wildcard ../../../build/pve-qemu-7.2-sparc/qemu-system-sparc64)", "")
++	cp ../../../build/pve-qemu-7.2-sparc/qemu-system-sparc64 $(destdir)/usr/bin/qemu-system-sparc64-7.2
++endif
++
++ifneq ("$(wildcard ../../../build/pve-qemu-3dfx/qemu-system-x86_64)", "")
++	cp ../../../build/pve-qemu-3dfx/qemu-system-x86_64 $(destdir)/usr/bin/qemu-system-x86_64-3dfx
++endif
++
++# Add extra system-sparc bios images
++ifneq ("$(wildcard ../../sparc/ss5.bin)", "")
++	cp ../../sparc/ss5.bin $(destdir)/usr/share/kvm/
++endif
++
++ifneq ("$(wildcard ../../sparc/ss10_v2.25_rom)", "")
++	cp ../../sparc/ss10_v2.25_rom $(destdir)/usr/share/kvm/
++endif
++
++ifneq ("$(wildcard ../../sparc/ss20_v2.25_rom)", "")
++	cp ../../sparc/ss20_v2.25_rom $(destdir)/usr/share/kvm/
++endif
++
+ 	# CPU flags are static for QEMU version, allows avoiding more costly checks
+ 	$(destdir)/usr/bin/qemu-system-x86_64 -cpu help | ./debian/parse-cpu-flags.pl > $(flagfile)
+ 
+ 	# Supported machine versions are static for a given QEMU binary.
+ 	$(destdir)/usr/bin/qemu-system-x86_64 -machine help | ./debian/parse-machines.pl > $(machine_file_x86_64)
+ 	$(destdir)/usr/bin/qemu-system-aarch64 -machine help | ./debian/parse-machines.pl > $(machine_file_aarch64)
++	$(destdir)/usr/bin/qemu-system-sparc -machine help | ./debian/parse-machines.pl > $(machine_file_sparc)
++	$(destdir)/usr/bin/qemu-system-sparc64 -machine help | ./debian/parse-machines.pl > $(machine_file_sparc64)
+ 
+ 	# Supported CPU models are static for a given QEMU binary.
+ 	$(destdir)/usr/bin/qemu-system-x86_64 -cpu help | ./debian/parse-cpu-models.pl > $(cpu_models_file_x86_64)


### PR DESCRIPTION
The debian package build failed during the check-patches workflow.

**Failed packages:**
- pve-qemu

**Failed workflow run:** https://github.com/hwinther/wsh-pve/actions/runs/29639098184

Please investigate and push fixes to this branch. Once the build succeeds, merge this PR.

**Rejected hunks (.rej files)** are included in the `patch-failures/` directory for reference.