### PR TITLE
Manual fix needed: pve-qemu deb build failed

### DIFF
--- a/.github/actions/create-deb-failure-pr/action.yml
+++ b/.github/actions/create-deb-failure-pr/action.yml
@@ -1,5 +1,5 @@
 name: Create PR for deb build failure
-description: Creates a branch and PR when deb build fails, assigning the user for manual fix
+description: Creates or updates a single branch and PR when deb build fails, assigning the user for manual fix
 
 inputs:
   token:
@@ -16,8 +16,8 @@ inputs:
     description: URL of the failed workflow run
     required: true
   run_id:
-    description: Workflow run ID (used for branch name)
-    required: true
+    description: Workflow run ID (informational; no longer used for the branch name)
+    required: false
   workflow_context:
     description: Context for PR body (e.g. sync-from-upstream, build-deb-trigger-patches)
     required: true
@@ -34,7 +34,7 @@ runs:
         ref: main
         token: ${{ inputs.token }}
 
-    - name: Create branch and PR for manual fix
+    - name: Create or update branch and PR for manual fix
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
@@ -42,7 +42,6 @@ runs:
         REJ_FILES_PATH: ${{ inputs.rej_files_path }}
         PR_ASSIGNEE: ${{ inputs.pr_assignee }}
         RUN_URL: ${{ inputs.run_url }}
-        RUN_ID: ${{ inputs.run_id }}
         WORKFLOW_CONTEXT: ${{ inputs.workflow_context }}
       run: |
         # Derive branch suffix and title from packages
@@ -62,17 +61,26 @@ runs:
 
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor }}@users.noreply.github.com"
-        branch_name="fix/deb-${branch_suffix}-${RUN_ID}"
-        git checkout -b "$branch_name"
+
+        # Stable, per-failure branch name (no run id) so at most ONE PR exists
+        # per failure signature at a time. The checkout step above left us on
+        # the tip of main, so resetting the branch to HEAD here rebases it onto
+        # the latest main on every failure run.
+        branch_name="fix/deb-${branch_suffix}"
+        git checkout -B "$branch_name"
 
         if [ -n "$REJ_FILES_PATH" ] && [ -d "$REJ_FILES_PATH" ]; then
+          rm -rf patch-failures
           cp -r "$REJ_FILES_PATH" patch-failures/
           git add patch-failures/
           git commit -m "Include rejected hunks (.rej) for manual patch fix"
         else
           git commit --allow-empty -m "Placeholder for manual patch fix - push your changes here"
         fi
-        git push origin "$branch_name"
+
+        # Force-push: the branch is always "latest main + this run's rejects",
+        # replacing any previous state so no stale duplicate branches pile up.
+        git push --force origin "$branch_name"
 
         body="The debian package build failed during the ${WORKFLOW_CONTEXT} workflow.
 
@@ -81,16 +89,27 @@ runs:
 
         **Failed workflow run:** ${RUN_URL}
 
-        Please investigate and push fixes to this branch. Once the build succeeds, merge this PR."
+        Please investigate and push fixes to this branch. Once the build succeeds, merge this PR.
+
+        > This branch is refreshed from the latest \`main\` on every failure run, so push fixes only after the most recent run or they may be overwritten."
         if [ -n "$REJ_FILES_PATH" ] && [ -d "$REJ_FILES_PATH" ]; then
           body="${body}
 
         **Rejected hunks (.rej files)** are included in the \`patch-failures/\` directory for reference."
         fi
 
-        gh pr create \
-          --base main \
-          --head "$branch_name" \
-          --title "$title" \
-          --body "$body" \
-          --assignee "$PR_ASSIGNEE"
+        # Reuse the existing open PR for this branch if there is one (the
+        # force-push above already refreshed its diff); otherwise open a new PR.
+        existing_pr=$(gh pr list --head "$branch_name" --state open --json number --jq '.[0].number // ""')
+        if [ -n "$existing_pr" ]; then
+          gh pr edit "$existing_pr" --title "$title" --body "$body" || true
+          gh pr edit "$existing_pr" --add-assignee "$PR_ASSIGNEE" || true
+          echo "Updated existing PR #${existing_pr} for ${branch_name}"
+        else
+          gh pr create \
+            --base main \
+            --head "$branch_name" \
+            --title "$title" \
+            --body "$body" \
+            --assignee "$PR_ASSIGNEE"
+        fi

--- a/submodules/pve-qemu.patch
+++ b/submodules/pve-qemu.patch
@@ -87,7 +87,7 @@ index 6fb5116..799c744 100644
 +pve-qemu-kvm: statically-linked-binary [usr/share/kvm/openbios-sparc64]
  pve-qemu-kvm: unstripped-binary-or-object [usr/share/kvm/hppa-firmware.img]
 diff --git a/debian/rules b/debian/rules
-index c90db29..7184da0 100755
+index a6b8745..df1bd77 100755
 --- a/debian/rules
 +++ b/debian/rules
 @@ -13,6 +13,8 @@ flagfile := $(destdir)/usr/share/kvm/recognized-CPUID-flags-x86_64
@@ -132,7 +132,7 @@ index c90db29..7184da0 100755
  	    --disable-smartcard \
  	    --disable-strip \
  	    --disable-xen \
-@@ -122,12 +124,40 @@ install: build
+@@ -126,6 +128,32 @@ install: build
  	rm -f $(destdir)/usr/lib/kvm/qemu-bridge-helper
  	rm -f $(destdir)/usr/lib/kvm/virtfs-proxy-helper
  
@@ -163,8 +163,9 @@ index c90db29..7184da0 100755
 +endif
 +
  	# CPU flags are static for QEMU version, allows avoiding more costly checks
- 	$(destdir)/usr/bin/qemu-system-x86_64 -cpu help | ./debian/parse-cpu-flags.pl > $(flagfile)
- 
+ 	./debian/parse-cpu-flags.pl $(destdir)/usr/bin/qemu-system-x86_64 max-x86_64-cpu > $(flagfile)
+ 	# NOTE: If the diff fails here after upgrading the QEMU submodule, check which new flags
+@@ -136,6 +164,8 @@ install: build
  	# Supported machine versions are static for a given QEMU binary.
  	$(destdir)/usr/bin/qemu-system-x86_64 -machine help | ./debian/parse-machines.pl > $(machine_file_x86_64)
  	$(destdir)/usr/bin/qemu-system-aarch64 -machine help | ./debian/parse-machines.pl > $(machine_file_aarch64)
@@ -173,7 +174,7 @@ index c90db29..7184da0 100755
  
  	# Supported CPU models are static for a given QEMU binary.
  	$(destdir)/usr/bin/qemu-system-x86_64 -cpu help | ./debian/parse-cpu-models.pl > $(cpu_models_file_x86_64)
-@@ -162,7 +192,7 @@ binary-arch: build install
+@@ -170,7 +200,7 @@ binary-arch: build install
  #	dh_installinfo
  	dh_installman
  	dh_link


### PR DESCRIPTION
The debian package build failed during the check-patches workflow.

**Failed packages:**
- pve-qemu

**Failed workflow run:** https://github.com/hwinther/wsh-pve/actions/runs/30153324294

Please investigate and push fixes to this branch. Once the build succeeds, merge this PR.

**Rejected hunks (.rej files)** are included in the `patch-failures/` directory for reference.