### PR TITLE
Add first-class floppy disk support (storage + backend + UI)

### DIFF
--- a/.github/workflows/build-deb-trigger-patches.yml
+++ b/.github/workflows/build-deb-trigger-patches.yml
@@ -15,6 +15,7 @@ on:
       - "submodules/pve-manager.patch"
       - "submodules/pve-qemu.patch"
       - "submodules/qemu-server.patch"
+      - "submodules/pve-storage.patch"
 
 permissions:
   # for ghcr.io (docker registry):
@@ -33,9 +34,11 @@ jobs:
       pve-manager: ${{ steps.changes.outputs.pve-manager }}
       pve-qemu: ${{ steps.changes.outputs.pve-qemu }}
       qemu-server: ${{ steps.changes.outputs.qemu-server }}
+      pve-storage: ${{ steps.changes.outputs.pve-storage }}
       pve-manager-count: ${{ steps.patch-count.outputs.pve-manager_changes }}
       pve-qemu-count: ${{ steps.patch-count.outputs.pve-qemu_changes }}
       qemu-server-count: ${{ steps.patch-count.outputs.qemu-server_changes }}
+      pve-storage-count: ${{ steps.patch-count.outputs.pve-storage_changes }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,6 +56,8 @@ jobs:
               - 'submodules/pve-qemu.patch'
             qemu-server:
               - 'submodules/qemu-server.patch'
+            pve-storage:
+              - 'submodules/pve-storage.patch'
 
       - name: Count amount of commits for each patch file
         id: patch-count
@@ -60,12 +65,15 @@ jobs:
           pve_manager_changes=$(git log --follow --pretty=oneline -- submodules/pve-manager.patch | wc -l)
           pve_qemu_changes=$(git log --follow --pretty=oneline -- submodules/pve-qemu.patch | wc -l)
           qemu_server_changes=$(git log --follow --pretty=oneline -- submodules/qemu-server.patch | wc -l)
+          pve_storage_changes=$(git log --follow --pretty=oneline -- submodules/pve-storage.patch | wc -l)
           echo "pve-manager_changes=$pve_manager_changes" >> $GITHUB_OUTPUT
           echo "pve-manager_changes=$pve_manager_changes"
           echo "pve-qemu_changes=$pve_qemu_changes" >> $GITHUB_OUTPUT
           echo "pve-qemu_changes=$pve_qemu_changes"
           echo "qemu-server_changes=$qemu_server_changes" >> $GITHUB_OUTPUT
           echo "qemu-server_changes=$qemu_server_changes"
+          echo "pve-storage_changes=$pve_storage_changes" >> $GITHUB_OUTPUT
+          echo "pve-storage_changes=$pve_storage_changes"
 
   build-pve-manager-deb-when-changed:
     uses: hwinther/wsh-pve/.github/workflows/build-deb.yml@main
@@ -91,6 +99,14 @@ jobs:
       package: qemu-server
     secrets: inherit
 
+  build-pve-storage-deb-when-changed:
+    uses: hwinther/wsh-pve/.github/workflows/build-deb.yml@main
+    needs: [check]
+    if: ${{ needs.check.outputs.pve-storage == 'true' }}
+    with:
+      package: pve-storage
+    secrets: inherit
+
   # debug-workflow:
   #   uses: hwinther/wsh-pve/.github/workflows/build-deb.yml@main
   #   needs: [check]
@@ -105,13 +121,15 @@ jobs:
         build-pve-manager-deb-when-changed,
         build-pve-qemu-deb-when-changed,
         build-qemu-server-deb-when-changed,
+        build-pve-storage-deb-when-changed,
       ]
     secrets: inherit
     if: |
       always() && (
         needs.build-pve-manager-deb-when-changed.result == 'success' ||
         needs.build-pve-qemu-deb-when-changed.result == 'success' ||
-        needs.build-qemu-server-deb-when-changed.result == 'success'
+        needs.build-qemu-server-deb-when-changed.result == 'success' ||
+        needs.build-pve-storage-deb-when-changed.result == 'success'
       )
 
   create-pr-on-build-failure:
@@ -122,12 +140,14 @@ jobs:
         build-pve-manager-deb-when-changed,
         build-pve-qemu-deb-when-changed,
         build-qemu-server-deb-when-changed,
+        build-pve-storage-deb-when-changed,
       ]
     if: |
       failure() && (
         (needs.check.outputs.pve-manager == 'true' && needs.build-pve-manager-deb-when-changed.result == 'failure') ||
         (needs.check.outputs.pve-qemu == 'true' && needs.build-pve-qemu-deb-when-changed.result == 'failure') ||
-        (needs.check.outputs.qemu-server == 'true' && needs.build-qemu-server-deb-when-changed.result == 'failure')
+        (needs.check.outputs.qemu-server == 'true' && needs.build-qemu-server-deb-when-changed.result == 'failure') ||
+        (needs.check.outputs.pve-storage == 'true' && needs.build-pve-storage-deb-when-changed.result == 'failure')
       )
     permissions:
       contents: write
@@ -140,6 +160,7 @@ jobs:
           [ "${{ needs.build-pve-manager-deb-when-changed.result }}" == "failure" ] && packs="${packs}pve-manager,"
           [ "${{ needs.build-pve-qemu-deb-when-changed.result }}" == "failure" ] && packs="${packs}pve-qemu,"
           [ "${{ needs.build-qemu-server-deb-when-changed.result }}" == "failure" ] && packs="${packs}qemu-server,"
+          [ "${{ needs.build-pve-storage-deb-when-changed.result }}" == "failure" ] && packs="${packs}pve-storage,"
           echo "packages=${packs%,}" >> $GITHUB_OUTPUT
 
       - name: Create PR for manual fix

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -12,6 +12,7 @@ on:
           - pve-manager
           - pve-qemu
           - qemu-server
+          - pve-storage
   workflow_call:
     inputs:
       package:

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -40,7 +40,7 @@ jobs:
           failed_packages=""
           changed_packages=""
 
-          for package in pve-manager qemu-server pve-qemu; do
+          for package in pve-manager qemu-server pve-qemu pve-storage; do
             echo "::group::Checking $package"
             git submodule update --init submodules/$package
 

--- a/.github/workflows/sync-from-upstream-trigger.yml
+++ b/.github/workflows/sync-from-upstream-trigger.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Trigger sync-qemu-server
         run: gh workflow run sync-qemu-server.yml --ref main
 
+  trigger-sync-pve-storage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync-pve-storage
+        run: gh workflow run sync-pve-storage.yml --ref main
+
   trigger-sync-qemu-3dfx:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-pve-storage.yml
+++ b/.github/workflows/sync-pve-storage.yml
@@ -1,0 +1,26 @@
+name: Sync pve-storage from upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 20 * * *"
+
+permissions:
+  packages: write
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  sync:
+    uses: hwinther/wsh-pve/.github/workflows/sync-from-upstream.yml@main
+    with:
+      repository: hwinther/pve-storage
+    secrets: inherit
+
+  update-docs:
+    uses: hwinther/wsh-pve/.github/workflows/repo-update.yml@main
+    needs: [sync]
+    if: needs.sync.outputs.build-deb-when-changed-success == 'true'
+    secrets: inherit

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "submodules/sparc"]
 	path = submodules/sparc
 	url = git@github.com:hwinther/sparc.git
+[submodule "submodules/pve-storage"]
+	path = submodules/pve-storage
+	url = https://github.com/hwinther/pve-storage.git

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ endif
 
 DOCKER_TTY := $(if $(DEBUG_SHELL),-it,)
 
-QEMU_SERVER_FILES := PVE/QemuServer.pm PVE/QemuServer/Helpers.pm PVE/QemuServer/Drive.pm PVE/QemuServer/DriveDevice.pm PVE/QemuServer/Machine.pm PVE/QemuServer/PCI.pm PVE/QemuServer/USB.pm PVE/QemuServer/Network.pm
+QEMU_SERVER_FILES := PVE/QemuServer.pm PVE/QemuServer/Helpers.pm PVE/QemuServer/Drive.pm PVE/QemuServer/DriveDevice.pm PVE/QemuServer/Machine.pm PVE/QemuServer/PCI.pm PVE/QemuServer/USB.pm PVE/QemuServer/Network.pm PVE/QemuServer/Blockdev.pm PVE/QemuConfig.pm PVE/API2/Qemu.pm
+PVE_STORAGE_FILES := PVE/Storage.pm PVE/Storage/Plugin.pm PVE/Storage/DirPlugin.pm PVE/Storage/NFSPlugin.pm PVE/Storage/CIFSPlugin.pm PVE/Storage/BTRFSPlugin.pm PVE/Storage/CephFSPlugin.pm PVE/API2/Storage/Status.pm
 PVE_MANAGER_FILES := manager6/pvemanagerlib.js css/ext6-pve.css
-PATCH_SUBMODULES := pve-manager pve-qemu qemu-server
+PATCH_SUBMODULES := pve-manager pve-qemu qemu-server pve-storage
 CURRENT_DIR = $(shell pwd)
 BRANCH_NAME := local_patches
 GIT_AUTHOR = $(shell git log -1 --pretty=format:%an -- Makefile)
@@ -71,7 +72,7 @@ build-containers:
 	sudo docker build . -f djgpp.Dockerfile -t wsh-pve-djgpp-build
 
 .PHONY: build
-build: pve-manager qemu-server pve-qemu-bundle
+build: pve-manager qemu-server pve-storage pve-qemu-bundle
 	echo Building all
 
 pve-manager-clean:
@@ -126,6 +127,34 @@ qemu-server:
 		-v /run/systemd/journal/socket:/run/systemd/journal/socket \
 		$(DOCKER_BUILD_IMAGE) \
 		bash -c 'git config --global --add safe.directory /src/submodules/qemu-server && make distclean && make deb; rc=$$?; if [ $$rc -ne 0 ]; then echo "BUILD FAILED (rc=$$rc)"; if [ "$(DEBUG_SHELL)" = "1" ]; then echo "Dropping to shell inside container"; exec /bin/bash; fi; fi; cp -f qemu-server_*.deb /build/repo/'; \
+	if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
+		echo "::endgroup::"; \
+	fi
+
+pve-storage-clean:
+	$(Q)$(ECHO) "INFO: Cleaning pve-storage"; \
+	rm -rf submodules/pve-storage; \
+	git submodule update --init submodules/pve-storage; \
+	$(MAKE) pve-storage
+
+.PHONY: pve-storage
+pve-storage:
+	$(Q)$(ECHO) "INFO: Building pve-storage deb package"; \
+		if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
+		echo "::group::Building pve-storage deb package"; \
+	fi; \
+	patch -d submodules/pve-storage -p1 --no-backup-if-mismatch --reject-file=/dev/null -i ../pve-storage.patch; \
+	$(DOCKER) run $(DOCKER_ARG) $(DOCKER_TTY) --rm --pull always \
+		-v $(CURRENT_DIR)/submodules/pve-storage:/src/submodules/pve-storage \
+		-v $(CURRENT_DIR)/.git:/src/.git \
+		-v $(CURRENT_DIR)/build/repo:/build/repo \
+		-w /src/submodules/pve-storage \
+		-e DEBEMAIL="$(GIT_EMAIL)" \
+		-e DEBFULLNAME="$(GIT_AUTHOR)" \
+		-e DEB_BUILD_OPTIONS=nocheck \
+		-v /run/systemd/journal/socket:/run/systemd/journal/socket \
+		$(DOCKER_BUILD_IMAGE) \
+		bash -c 'git config --global --add safe.directory /src/submodules/pve-storage && make distclean && make deb; rc=$$?; if [ $$rc -ne 0 ]; then echo "BUILD FAILED (rc=$$rc)"; if [ "$(DEBUG_SHELL)" = "1" ]; then echo "Dropping to shell inside container"; exec /bin/bash; fi; fi; cp -f libpve-storage-perl_*.deb /build/repo/'; \
 	if [ "$(GITHUB_ACTIONS)" = "true" ]; then \
 		echo "::endgroup::"; \
 	fi
@@ -251,6 +280,20 @@ dev-links:
 		if [ ! -e "$$symlink_path" ]; then \
 			$(ECHO) "INFO: Creating symlink to $$symlink_path"; \
 			ln -s "$(CURRENT_DIR)/submodules/qemu-server/src/$$item" "$$symlink_path"; \
+		fi; \
+	done
+
+	$(Q)for item in $(PVE_STORAGE_FILES); do \
+		symlink_path="/usr/share/perl5/$$item"; \
+		if [ -L "$$symlink_path" ]; then \
+			$(ECHO) "INFO: $$symlink_path is already a symlink"; \
+		elif [ -e "$$symlink_path" ]; then \
+			$(ECHO) "INFO: $$symlink_path exists but is not a symlink"; \
+			rm -f "$$symlink_path"; \
+		fi; \
+		if [ ! -e "$$symlink_path" ]; then \
+			$(ECHO) "INFO: Creating symlink to $$symlink_path"; \
+			ln -s "$(CURRENT_DIR)/submodules/pve-storage/src/$$item" "$$symlink_path"; \
 		fi; \
 	done
 
@@ -416,7 +459,7 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  all:                     Initialize submodules and build all components"
-	@echo "  build:                   Build all components (pve-manager, qemu-server, pve-qemu-bundle)"
+	@echo "  build:                   Build all components (pve-manager, qemu-server, pve-storage, pve-qemu-bundle)"
 	@echo "  build-containers:        Build Docker containers for development"
 	@echo "  init-submodules:         Check and reinitialize git submodules"
 	@echo "  reset-submodules:        Deletes and initializes git submodules (WARNING: potential loss of data if there are local patches)"
@@ -429,6 +472,8 @@ help:
 	@echo "  qemu-server:             Build qemu-server deb package"
 	@echo "  qemu-server-clean:       Clean and rebuild qemu-server"
 	@echo "  qemu-server-dev:         Restart PVE services for development"
+	@echo "  pve-storage:             Build pve-storage (libpve-storage-perl) deb package"
+	@echo "  pve-storage-clean:       Clean and rebuild pve-storage"
 	@echo "  pve-qemu:                Build pve-qemu deb package"
 	@echo "  pve-qemu-7.2-sparc:      Build SPARC-specific QEMU 7.2 binaries"
 	@echo "  pve-qemu-3dfx:           Build QEMU with 3dfx support"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once the packages have been installed on a PVE host, the proxmox frontend will h
   * Audio does not seem to work, but network is working so long as it is present when solaris is installed
   * The installation process may take a long time, and CPU usage will be stuck at around 100% on the host - this is normal, but you may want to pin the cpu core to a low frequency core or stick to a test system so that the performance is not reduced for other guests.
 
-* TODO: add feature for floppy mounting
+* Floppy disk support: a dedicated `floppy` storage content type (stored in `template/floppy` next to the iso folder) with upload/listing in the UI, up to two floppy drives per VM (A:/B:) with boot-from-floppy and live media swap - see the [floppy reference](https://debian.wshosting.no/reference/floppy/)
 
 * Selecting an architecture and CPU outside of the default x86(-64) set
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,5 +12,4 @@ TODO
 - Setup CI to deploy to the apt repo
 - Add VNC audio support
 - Add support for selecting in UI and using other architectures such as sparc64
-- Add support for selecting floppy images in UI
 - Add support for adding/changing hookscripts in UI

--- a/docs/src/content/docs/reference/floppy.md
+++ b/docs/src/content/docs/reference/floppy.md
@@ -3,5 +3,65 @@ title: Floppy Device Reference
 description: A reference page for the floppy hardware panel.
 ---
 
-Reference pages are ideal for outlining how things work in terse and clear terms.
-Less concerned with telling a story or addressing a specific use case, they should give a comprehensive outline of what you're documenting.
+The WSH patches add first-class floppy disk support to Proxmox VE: floppy images are a dedicated storage content type, and VMs can have up to two floppy drives (`floppy0` = A:, `floppy1` = B:) that show up in the Hardware panel next to the CD/DVD drive. This is mainly aimed at DOS-era and Windows 9x guests, which often need boot or driver floppies during installation.
+
+## Storage setup
+
+Floppy images use the `floppy` content type and live in `template/floppy/` next to `template/iso/` on directory-based storages (Directory, NFS, CIFS, BTRFS, CephFS).
+
+1. Go to **Datacenter → Storage**, edit a storage and enable the **Floppy image** content type. The `template/floppy` directory is created automatically when the storage is activated.
+2. A **Floppy Images** tab appears on the storage, with upload and download-from-URL support. Accepted extensions are `.img`, `.ima` and `.vfd`.
+
+Note: `.img` files are accepted by both the ISO Images and the Floppy Images upload dialogs — the tab you upload through decides whether the file becomes an `iso/` or a `floppy/` volume, so make sure to use the Floppy Images tab for floppy images.
+
+## Adding a floppy drive
+
+In the VM's **Hardware** panel choose **Add → Floppy Drive**, pick the drive number (0 = A:, 1 = B:) and select a floppy image — or attach one from the CLI:
+
+```sh
+qm set 100 --floppy0 local:floppy/dos622-boot.img
+```
+
+An empty drive can be configured with `--floppy0 none`, useful when the guest OS should be able to have media inserted later.
+
+On `i440fx` machines the floppy drives attach to the chipset's onboard floppy controller; on `q35` an `isa-fdc` controller is added automatically.
+
+## Booting from floppy
+
+Floppy drives appear in **Options → Boot Order** like any other bootable device:
+
+```sh
+qm set 100 --boot order=floppy0;ide0
+```
+
+The legacy boot letter `a` (`boot: a`) also maps to the floppy drives.
+
+## Swapping disks on a running VM
+
+Editing the floppy drive of a running VM swaps the medium live — no restart needed. This makes multi-disk installations (installer asks for "disk 2") work the same way as changing a CD. Adding or removing a whole floppy *drive* on a running VM is registered as a pending change and applied on the next restart.
+
+## Write behaviour
+
+Floppy drives are **writable by default**, matching real hardware — DOS installers and guests frequently write volume labels, settings or files to floppies. Add `ro=1` to make a drive read-only:
+
+```sh
+qm set 100 --floppy0 local:floppy/master-boot.img,ro=1
+```
+
+Keep in mind that images in `template/floppy/` are shared:
+
+- Two VMs mounting the same image writable at the same time can corrupt it.
+- Floppy volumes are treated as removable reference media (like ISOs): they are **not** included in backups or snapshots, are not copied on clone (the clone references the same image), and are never deleted when a VM is destroyed. A snapshot rollback does not roll back floppy contents.
+
+If a guest needs a private writable floppy, upload a copy of the image first.
+
+## Limitations
+
+- Maximum of two floppy drives per VM (`floppy0`, `floppy1`).
+- x86_64 guests only.
+- Floppy drive add/remove on a running VM is a pending change (media swap is live).
+
+## Further reading
+
+- [Machine Reference](/reference/machine/) — i440fx vs q35
+- [Operating Systems guide](/guides/operating-systems/) — DOS and Windows 9x notes

--- a/repo.Dockerfile
+++ b/repo.Dockerfile
@@ -3,12 +3,14 @@ FROM ghcr.io/hwinther/wsh-pve/reprepro:latest AS install
 FROM ghcr.io/hwinther/wsh-pve/qemu-server:latest AS qemu-server
 FROM ghcr.io/hwinther/wsh-pve/pve-qemu:latest AS pve-qemu
 FROM ghcr.io/hwinther/wsh-pve/pve-manager:latest AS pve-manager
+FROM ghcr.io/hwinther/wsh-pve/pve-storage:latest AS pve-storage
 
 FROM install AS final
 RUN mkdir -p /opt/repo-incoming
 COPY --from=qemu-server /opt/repo/*.deb /opt/repo-incoming/
 COPY --from=pve-qemu /opt/repo/*.deb /opt/repo-incoming/
 COPY --from=pve-manager /opt/repo/*.deb /opt/repo-incoming/
+COPY --from=pve-storage /opt/repo/*.deb /opt/repo-incoming/
 
 WORKDIR /opt/repo
 COPY .gpg /tmp/.gpg-key

--- a/submodules/pve-manager.patch
+++ b/submodules/pve-manager.patch
@@ -1,7 +1,19 @@
-diff --git a/www/css/ext6-pve.css b/www/css/ext6-pve.css
-index 5c37dd29..6f6513ae 100644
---- a/www/css/ext6-pve.css
-+++ b/www/css/ext6-pve.css
+diff --git c/Makefile i/Makefile
+index 6c8b82e1a..bf3064145 100644
+--- c/Makefile
++++ i/Makefile
+@@ -65,6 +65,7 @@ install: vzdump-hook-script.pl
+ 	install -d $(DESTDIR)/var/lib/vz/images
+ 	install -d $(DESTDIR)/var/lib/vz/template/cache
+ 	install -d $(DESTDIR)/var/lib/vz/template/iso
++	install -d $(DESTDIR)/var/lib/vz/template/floppy
+ 	install -m 0644 vzdump-hook-script.pl $(DOCDIR)/examples/vzdump-hook-script.pl
+ 	install -m 0644 spice-example-sh $(DOCDIR)/examples/spice-example-sh
+ 	set -e && for i in $(SUBDIRS); do $(MAKE) -C $$i $@; done
+diff --git c/www/css/ext6-pve.css i/www/css/ext6-pve.css
+index 5c37dd291..6f6513ae6 100644
+--- c/www/css/ext6-pve.css
++++ i/www/css/ext6-pve.css
 @@ -688,3 +688,121 @@ table.osds td:first-of-type {
  .pmx-column-wrapped > div {
      white-space: pre-wrap;
@@ -124,11 +136,27 @@ index 5c37dd29..6f6513ae 100644
 +.fa-database       { color: #70a1c8 !important; }
 +
 +.fa-object-group           { color: #56bbe8 !important; }
-diff --git a/www/manager6/Makefile b/www/manager6/Makefile
-index d4dd3f35..328f5dfc 100644
---- a/www/manager6/Makefile
-+++ b/www/manager6/Makefile
-@@ -280,6 +280,7 @@ JSSRC= 							\
+diff --git c/www/manager6/Makefile i/www/manager6/Makefile
+index d4dd3f351..39b1a7c38 100644
+--- c/www/manager6/Makefile
++++ i/www/manager6/Makefile
+@@ -97,6 +97,7 @@ JSSRC= 							\
+ 	form/MultiFileButton.js				\
+ 	form/TagFieldSet.js				\
+ 	form/IsoSelector.js				\
++	form/FloppySelector.js				\
+ 	grid/BackupView.js				\
+ 	grid/FirewallAliases.js				\
+ 	grid/FirewallOptions.js				\
+@@ -255,6 +256,7 @@ JSSRC= 							\
+ 	qemu/AudioEdit.js				\
+ 	qemu/BootOrderEdit.js				\
+ 	qemu/CDEdit.js					\
++	qemu/FloppyEdit.js				\
+ 	qemu/CIDriveEdit.js				\
+ 	qemu/CloudInit.js				\
+ 	qemu/CmdMenu.js					\
+@@ -280,6 +282,7 @@ JSSRC= 							\
  	qemu/Options.js					\
  	qemu/PCIEdit.js					\
  	qemu/ProcessorEdit.js				\
@@ -136,10 +164,10 @@ index d4dd3f35..328f5dfc 100644
  	qemu/QemuBiosEdit.js				\
  	qemu/RNGEdit.js					\
  	qemu/SSHKey.js					\
-diff --git a/www/manager6/Parser.js b/www/manager6/Parser.js
-index 36df8e9d..ab605518 100644
---- a/www/manager6/Parser.js
-+++ b/www/manager6/Parser.js
+diff --git c/www/manager6/Parser.js i/www/manager6/Parser.js
+index 36df8e9d5..ab6055189 100644
+--- c/www/manager6/Parser.js
++++ i/www/manager6/Parser.js
 @@ -117,7 +117,7 @@ Ext.define('PVE.Parser', {
  
                  if (
@@ -149,10 +177,10 @@ index 36df8e9d..ab605518 100644
                      )) !== null
                  ) {
                      res.model = match_res[1].toLowerCase();
-diff --git a/www/manager6/Utils.js b/www/manager6/Utils.js
-index 040b5ae0..f814c1db 100644
---- a/www/manager6/Utils.js
-+++ b/www/manager6/Utils.js
+diff --git c/www/manager6/Utils.js i/www/manager6/Utils.js
+index 040b5ae01..a5bd0cc35 100644
+--- c/www/manager6/Utils.js
++++ i/www/manager6/Utils.js
 @@ -145,7 +145,7 @@ Ext.define('PVE.Utils', {
                  bvers = b.toString().split('.');
              }
@@ -199,7 +227,23 @@ index 040b5ae0..f814c1db 100644
              vmware: gettext('VMware compatible'),
              qxl: 'SPICE',
              qxl2: 'SPICE dual monitor',
-@@ -1902,8 +1918,8 @@ Ext.define('PVE.Utils', {
+@@ -737,6 +753,7 @@ Ext.define('PVE.Utils', {
+             backup: gettext('Backup'),
+             vztmpl: gettext('Container template'),
+             iso: gettext('ISO image'),
++            floppy: gettext('Floppy image'),
+             rootdir: gettext('Container'),
+             snippets: gettext('Snippets'),
+             import: gettext('Import'),
+@@ -1783,6 +1800,7 @@ Ext.define('PVE.Utils', {
+             rng: 1,
+             tpmstate: 1,
+             virtiofs: 10,
++            floppy: 2,
+         },
+ 
+         // we can have usb6 and up only for specific machine/ostypes
+@@ -1902,8 +1920,8 @@ Ext.define('PVE.Utils', {
                      container.mask(
                          Ext.String.format(
                              gettext('{0} not installed.') +
@@ -210,10 +254,143 @@ index 040b5ae0..f814c1db 100644
                              'Ceph',
                          ),
                          ['pve-static-mask'],
-diff --git a/www/manager6/form/NetworkCardSelector.js b/www/manager6/form/NetworkCardSelector.js
-index a6630418..0703f3ca 100644
---- a/www/manager6/form/NetworkCardSelector.js
-+++ b/www/manager6/form/NetworkCardSelector.js
+diff --git c/www/manager6/form/ContentTypeSelector.js i/www/manager6/form/ContentTypeSelector.js
+index 605322516..7e6493900 100644
+--- c/www/manager6/form/ContentTypeSelector.js
++++ i/www/manager6/form/ContentTypeSelector.js
+@@ -10,7 +10,7 @@ Ext.define('PVE.form.ContentTypeSelector', {
+         me.comboItems = [];
+ 
+         if (me.cts === undefined) {
+-            me.cts = ['images', 'iso', 'vztmpl', 'backup', 'rootdir', 'snippets', 'import'];
++            me.cts = ['images', 'iso', 'floppy', 'vztmpl', 'backup', 'rootdir', 'snippets', 'import'];
+         }
+ 
+         Ext.Array.each(me.cts, function (ct) {
+diff --git c/www/manager6/form/FloppySelector.js i/www/manager6/form/FloppySelector.js
+new file mode 100644
+index 000000000..2277bc65e
+--- /dev/null
++++ i/www/manager6/form/FloppySelector.js
+@@ -0,0 +1,114 @@
++Ext.define('PVE.form.FloppySelector', {
++    extend: 'Ext.container.Container',
++    alias: 'widget.pveFloppySelector',
++    mixins: ['Ext.form.field.Field', 'Proxmox.Mixin.CBind'],
++
++    layout: {
++        type: 'vbox',
++        align: 'stretch',
++    },
++
++    nodename: undefined,
++    insideWizard: false,
++    labelWidth: undefined,
++    labelAlign: 'right',
++
++    cbindData: function () {
++        let me = this;
++        return {
++            nodename: me.nodename,
++            insideWizard: me.insideWizard,
++        };
++    },
++
++    getValue: function () {
++        return this.lookup('file').getValue();
++    },
++
++    setValue: function (value) {
++        let me = this;
++        if (!value) {
++            me.lookup('file').reset();
++            return;
++        }
++        var match = value.match(/^([^:]+):/);
++        if (match) {
++            me.lookup('storage').setValue(match[1]);
++            me.lookup('file').setValue(value);
++        }
++    },
++
++    getErrors: function () {
++        let me = this;
++        me.lookup('storage').validate();
++        let file = me.lookup('file');
++        file.validate();
++        let value = file.getValue();
++        if (!value || !value.length) {
++            return ['']; // for validation
++        }
++        return [];
++    },
++
++    setNodename: function (nodename) {
++        let me = this;
++        me.lookup('storage').setNodename(nodename);
++        me.lookup('file').setStorage(undefined, nodename);
++    },
++
++    setDisabled: function (disabled) {
++        let me = this;
++        me.lookup('storage').setDisabled(disabled);
++        me.lookup('file').setDisabled(disabled);
++        return me.callParent([disabled]);
++    },
++
++    referenceHolder: true,
++
++    items: [
++        {
++            xtype: 'pveStorageSelector',
++            reference: 'storage',
++            isFormField: false,
++            fieldLabel: gettext('Storage'),
++            storageContent: 'floppy',
++            allowBlank: false,
++            cbind: {
++                nodename: '{nodename}',
++                autoSelect: '{insideWizard}',
++                insideWizard: '{insideWizard}',
++                disabled: '{disabled}',
++                labelWidth: '{labelWidth}',
++                labelAlign: '{labelAlign}',
++            },
++            listeners: {
++                change: function (f, value) {
++                    let me = this;
++                    let selector = me.up('pveFloppySelector');
++                    selector.lookup('file').setStorage(value);
++                    selector.checkChange();
++                },
++            },
++        },
++        {
++            xtype: 'pveFileSelector',
++            reference: 'file',
++            isFormField: false,
++            storageContent: 'floppy',
++            fieldLabel: gettext('Floppy image'),
++            labelAlign: 'right',
++            cbind: {
++                nodename: '{nodename}',
++                disabled: '{disabled}',
++                labelWidth: '{labelWidth}',
++                labelAlign: '{labelAlign}',
++            },
++            allowBlank: false,
++            listeners: {
++                change: function () {
++                    this.up('pveFloppySelector').checkChange();
++                },
++            },
++        },
++    ],
++});
+diff --git c/www/manager6/form/NetworkCardSelector.js i/www/manager6/form/NetworkCardSelector.js
+index a66304182..0703f3ca5 100644
+--- c/www/manager6/form/NetworkCardSelector.js
++++ i/www/manager6/form/NetworkCardSelector.js
 @@ -7,5 +7,9 @@ Ext.define('PVE.form.NetworkCardSelector', {
          ['virtio', 'VirtIO (' + gettext('paravirtualized') + ')'],
          ['rtl8139', 'Realtek RTL8139'],
@@ -224,10 +401,10 @@ index a6630418..0703f3ca 100644
 +        ['lance', 'Lance Am7990 (sparc only)'],
      ],
  });
-diff --git a/www/manager6/form/QemuBiosSelector.js b/www/manager6/form/QemuBiosSelector.js
-index 40abb589..b66ac01c 100644
---- a/www/manager6/form/QemuBiosSelector.js
-+++ b/www/manager6/form/QemuBiosSelector.js
+diff --git c/www/manager6/form/QemuBiosSelector.js i/www/manager6/form/QemuBiosSelector.js
+index 40abb589b..b66ac01cb 100644
+--- c/www/manager6/form/QemuBiosSelector.js
++++ i/www/manager6/form/QemuBiosSelector.js
 @@ -6,6 +6,11 @@ Ext.define('PVE.form.QemuBiosSelector', {
          ['__default__', PVE.Utils.render_qemu_bios('')],
          ['seabios', PVE.Utils.render_qemu_bios('seabios')],
@@ -240,10 +417,10 @@ index 40abb589..b66ac01c 100644
      ],
  
      allowedValuesPerCategory: PVE.qemu.Architecture.allowedFirmware,
-diff --git a/www/manager6/form/QemuMachineSelector.js b/www/manager6/form/QemuMachineSelector.js
-index faeb530a..5b8f9690 100644
---- a/www/manager6/form/QemuMachineSelector.js
-+++ b/www/manager6/form/QemuMachineSelector.js
+diff --git c/www/manager6/form/QemuMachineSelector.js i/www/manager6/form/QemuMachineSelector.js
+index faeb530af..5b8f9690d 100644
+--- c/www/manager6/form/QemuMachineSelector.js
++++ i/www/manager6/form/QemuMachineSelector.js
 @@ -5,6 +5,8 @@ Ext.define('PVE.form.QemuMachineSelector', {
      comboItems: [
          ['__default__', PVE.Utils.render_qemu_machine('')],
@@ -253,10 +430,10 @@ index faeb530a..5b8f9690 100644
      ],
  
      allowedValuesPerCategory: PVE.qemu.Architecture.allowedMachines,
-diff --git a/www/manager6/qemu/Architecture.js b/www/manager6/qemu/Architecture.js
-index f7de1ebe..9ce7990e 100644
---- a/www/manager6/qemu/Architecture.js
-+++ b/www/manager6/qemu/Architecture.js
+diff --git c/www/manager6/qemu/Architecture.js i/www/manager6/qemu/Architecture.js
+index f7de1ebe7..9ce7990e9 100644
+--- c/www/manager6/qemu/Architecture.js
++++ i/www/manager6/qemu/Architecture.js
 @@ -10,6 +10,8 @@ Ext.define('PVE.qemu.Architecture', {
          ['__default__', `${Proxmox.Utils.defaultText} (${gettext('Host Architecture')})`],
          ['x86_64', gettext('x86 (64-bit)')],
@@ -339,10 +516,10 @@ index f7de1ebe..9ce7990e 100644
              default:
                  return Proxmox.Utils.unknownText;
          }
-diff --git a/www/manager6/qemu/AudioEdit.js b/www/manager6/qemu/AudioEdit.js
-index ba588edc..01ba47ea 100644
---- a/www/manager6/qemu/AudioEdit.js
-+++ b/www/manager6/qemu/AudioEdit.js
+diff --git c/www/manager6/qemu/AudioEdit.js i/www/manager6/qemu/AudioEdit.js
+index ba588edcd..01ba47eac 100644
+--- c/www/manager6/qemu/AudioEdit.js
++++ i/www/manager6/qemu/AudioEdit.js
 @@ -16,6 +16,12 @@ Ext.define('PVE.qemu.AudioInputPanel', {
          };
      },
@@ -405,10 +582,22 @@ index ba588edc..01ba47ea 100644
          },
      ],
  });
-diff --git a/www/manager6/qemu/CDEdit.js b/www/manager6/qemu/CDEdit.js
-index c185de53..e807ac49 100644
---- a/www/manager6/qemu/CDEdit.js
-+++ b/www/manager6/qemu/CDEdit.js
+diff --git c/www/manager6/qemu/BootOrderEdit.js i/www/manager6/qemu/BootOrderEdit.js
+index 6239aeca6..0f12a83e7 100644
+--- c/www/manager6/qemu/BootOrderEdit.js
++++ i/www/manager6/qemu/BootOrderEdit.js
+@@ -69,6 +69,7 @@ Ext.define('PVE.qemu.BootOrderPanel', {
+     isBootdev: function (dev, value) {
+         return (
+             (this.isDisk(dev) && !this.isCloudinit(value)) ||
++            /^floppy\d+/.test(dev) ||
+             /^net\d+/.test(dev) ||
+             /^hostpci\d+/.test(dev) ||
+             (/^usb\d+/.test(dev) && !/spice/.test(value))
+diff --git c/www/manager6/qemu/CDEdit.js i/www/manager6/qemu/CDEdit.js
+index c185de533..e807ac49c 100644
+--- c/www/manager6/qemu/CDEdit.js
++++ i/www/manager6/qemu/CDEdit.js
 @@ -69,7 +69,7 @@ Ext.define('PVE.qemu.CDInputPanel', {
  
          if (!me.confid) {
@@ -418,10 +607,10 @@ index c185de53..e807ac49 100644
                  nodename: me.nodename,
              });
              items.push(me.bussel);
-diff --git a/www/manager6/qemu/DisplayEdit.js b/www/manager6/qemu/DisplayEdit.js
-index 3f583adb..bd457b09 100644
---- a/www/manager6/qemu/DisplayEdit.js
-+++ b/www/manager6/qemu/DisplayEdit.js
+diff --git c/www/manager6/qemu/DisplayEdit.js i/www/manager6/qemu/DisplayEdit.js
+index 3f583adbe..bd457b09e 100644
+--- c/www/manager6/qemu/DisplayEdit.js
++++ i/www/manager6/qemu/DisplayEdit.js
 @@ -74,6 +74,20 @@ Ext.define('PVE.qemu.DisplayInputPanel', {
                  emptyText: '{memoryEmptyText}',
                  disabled: '{matchNonGUIOption}',
@@ -443,11 +632,238 @@ index 3f583adb..bd457b09 100644
          },
      ],
  
-diff --git a/www/manager6/qemu/HardwareView.js b/www/manager6/qemu/HardwareView.js
-index e6c02299..ab6ab9db 100644
---- a/www/manager6/qemu/HardwareView.js
-+++ b/www/manager6/qemu/HardwareView.js
-@@ -789,10 +789,10 @@ Ext.define('PVE.qemu.HardwareView', {
+diff --git c/www/manager6/qemu/FloppyEdit.js i/www/manager6/qemu/FloppyEdit.js
+new file mode 100644
+index 000000000..39eb17884
+--- /dev/null
++++ i/www/manager6/qemu/FloppyEdit.js
+@@ -0,0 +1,194 @@
++Ext.define('PVE.qemu.FloppyInputPanel', {
++    extend: 'Proxmox.panel.InputPanel',
++    alias: 'widget.pveQemuFloppyInputPanel',
++
++    insideWizard: false,
++
++    vmconfig: {}, // used to check for existing devices
++
++    onGetValues: function (values) {
++        var me = this;
++
++        var confid = me.confid || 'floppy' + values.deviceid;
++
++        if (values.mediaType === 'image') {
++            me.drive.file = values.floppyimage;
++        } else {
++            me.drive.file = 'none';
++        }
++
++        if (values.ro) {
++            me.drive.ro = 1;
++        } else {
++            delete me.drive.ro;
++        }
++
++        var params = {};
++
++        params[confid] = PVE.Parser.printQemuDrive(me.drive);
++
++        return params;
++    },
++
++    setVMConfig: function (vmconfig) {
++        var me = this;
++
++        me.vmconfig = Ext.apply({}, vmconfig);
++
++        let field = me.down('field[name=deviceid]');
++        if (field) {
++            for (let i = 0; i < 2; i++) {
++                if (!Ext.isDefined(me.vmconfig[`floppy${i}`])) {
++                    field.setValue(i);
++                    break;
++                }
++            }
++            field.validate();
++        }
++    },
++
++    setDrive: function (drive) {
++        var me = this;
++
++        var values = {};
++        if (drive.file === 'none') {
++            values.mediaType = 'none';
++        } else {
++            values.mediaType = 'image';
++            values.floppyimage = drive.file;
++        }
++        values.ro = drive.ro;
++
++        me.drive = drive;
++
++        me.setValues(values);
++    },
++
++    setNodename: function (nodename) {
++        var me = this;
++
++        me.floppysel.setNodename(nodename);
++    },
++
++    initComponent: function () {
++        var me = this;
++
++        me.drive = {};
++
++        var items = [];
++
++        if (!me.confid) {
++            items.push({
++                xtype: 'proxmoxintegerfield',
++                name: 'deviceid',
++                fieldLabel: gettext('Drive number'),
++                minValue: 0,
++                maxValue: 1,
++                value: '0',
++                allowBlank: false,
++                validator: function (value) {
++                    if (!me.rendered) {
++                        return undefined;
++                    }
++                    if (Ext.isDefined(me.vmconfig[`floppy${value}`])) {
++                        return 'This device is already in use.';
++                    }
++                    return true;
++                },
++            });
++        }
++
++        items.push({
++            xtype: 'radiofield',
++            name: 'mediaType',
++            inputValue: 'image',
++            boxLabel: gettext('Use floppy disk image file'),
++            checked: true,
++            listeners: {
++                change: function (f, value) {
++                    if (!me.rendered) {
++                        return;
++                    }
++                    var imageField = me.down('pveFloppySelector');
++                    imageField.setDisabled(!value);
++                    if (value) {
++                        imageField.validate();
++                    } else {
++                        imageField.reset();
++                    }
++                },
++            },
++        });
++
++        me.floppysel = Ext.create('PVE.form.FloppySelector', {
++            nodename: me.nodename,
++            insideWizard: me.insideWizard,
++            name: 'floppyimage',
++        });
++
++        items.push(me.floppysel);
++
++        items.push({
++            xtype: 'radiofield',
++            name: 'mediaType',
++            inputValue: 'none',
++            boxLabel: gettext('Do not use any media'),
++        });
++
++        items.push({
++            xtype: 'proxmoxcheckbox',
++            name: 'ro',
++            fieldLabel: gettext('Read-only'),
++            uncheckedValue: 0,
++        });
++
++        me.items = items;
++
++        me.callParent();
++    },
++});
++
++Ext.define('PVE.qemu.FloppyEdit', {
++    extend: 'Proxmox.window.Edit',
++
++    width: 400,
++
++    initComponent: function () {
++        var me = this;
++
++        var nodename = me.pveSelNode.data.node;
++        if (!nodename) {
++            throw 'no node name specified';
++        }
++
++        me.isCreate = !me.confid;
++
++        var ipanel = Ext.create('PVE.qemu.FloppyInputPanel', {
++            confid: me.confid,
++            nodename: nodename,
++        });
++
++        Ext.applyIf(me, {
++            subject: gettext('Floppy Drive'),
++            items: [ipanel],
++        });
++
++        me.callParent();
++
++        me.load({
++            success: function (response, options) {
++                ipanel.setVMConfig(response.result.data);
++                if (me.confid) {
++                    let value = response.result.data[me.confid];
++                    let drive = PVE.Parser.parseQemuDrive(me.confid, value);
++                    if (!drive) {
++                        Ext.Msg.alert('Error', 'Unable to parse drive options');
++                        me.close();
++                        return;
++                    }
++                    ipanel.setDrive(drive);
++                }
++            },
++        });
++    },
++});
+diff --git c/www/manager6/qemu/HardwareView.js i/www/manager6/qemu/HardwareView.js
+index e6c02299a..f07944a89 100644
+--- c/www/manager6/qemu/HardwareView.js
++++ i/www/manager6/qemu/HardwareView.js
+@@ -299,6 +299,18 @@ Ext.define('PVE.qemu.HardwareView', {
+             header: gettext('TPM State'),
+             renderer: Ext.htmlEncode,
+         };
++        for (let i = 0; i < PVE.Utils.hardware_counts.floppy; i++) {
++            let confid = 'floppy' + i.toString();
++            rows[confid] = {
++                group: 23,
++                order: i,
++                iconCls: 'floppy-o',
++                editor: caps.vms['VM.Config.CDROM'] ? 'PVE.qemu.FloppyEdit' : undefined,
++                never_delete: !caps.vms['VM.Config.CDROM'],
++                header: gettext('Floppy Drive') + ' (' + confid + ')',
++                renderer: Ext.htmlEncode,
++            };
++        }
+         for (let i = 0; i < PVE.Utils.hardware_counts.usb; i++) {
+             let confid = 'usb' + i.toString();
+             rows[confid] = {
+@@ -741,6 +753,7 @@ Ext.define('PVE.qemu.HardwareView', {
+             me.down('#addCloudinitDrive').setDisabled(
+                 noVMConfigCDROMPerm || noVMConfigCloudinitPerm || hasCloudInit,
+             );
++            me.down('#addFloppy').setDisabled(noVMConfigCDROMPerm || isAtLimit('floppy'));
+ 
+             if (!rec) {
+                 remove_btn.disable();
+@@ -789,10 +802,10 @@ Ext.define('PVE.qemu.HardwareView', {
  
              edit_btn.setDisabled(
                  deleted ||
@@ -462,7 +878,21 @@ index e6c02299..ab6ab9db 100644
              );
  
              diskaction_btn.setDisabled(
-@@ -918,6 +918,13 @@ Ext.define('PVE.qemu.HardwareView', {
+@@ -849,6 +862,13 @@ Ext.define('PVE.qemu.HardwareView', {
+                                 disabled: !caps.vms['VM.Config.CDROM'],
+                                 handler: editorFactory('CDEdit'),
+                             },
++                            {
++                                text: gettext('Floppy Drive'),
++                                itemId: 'addFloppy',
++                                iconCls: 'fa fa-fw fa-floppy-o black',
++                                disabled: !caps.vms['VM.Config.CDROM'],
++                                handler: editorFactory('FloppyEdit'),
++                            },
+                             {
+                                 text: gettext('Network Device'),
+                                 itemId: 'addNet',
+@@ -918,6 +938,13 @@ Ext.define('PVE.qemu.HardwareView', {
                                  disabled: !caps.nodes['Sys.Console'],
                                  handler: editorFactory('VirtiofsEdit'),
                              },
@@ -476,10 +906,10 @@ index e6c02299..ab6ab9db 100644
                          ],
                      }),
                  },
-diff --git a/www/manager6/qemu/MachineEdit.js b/www/manager6/qemu/MachineEdit.js
-index 4b1a9e83..c60dd001 100644
---- a/www/manager6/qemu/MachineEdit.js
-+++ b/www/manager6/qemu/MachineEdit.js
+diff --git c/www/manager6/qemu/MachineEdit.js i/www/manager6/qemu/MachineEdit.js
+index 4b1a9e833..c60dd0010 100644
+--- c/www/manager6/qemu/MachineEdit.js
++++ i/www/manager6/qemu/MachineEdit.js
 @@ -51,7 +51,16 @@ Ext.define('PVE.qemu.MachineInputPanel', {
              if (defaultMachine === 'pc') {
                  defaultMachine = 'i440fx'; // the default in the backend is 'pc' which means 'i440fx' for the qemu machinetype
@@ -552,11 +982,11 @@ index 4b1a9e83..c60dd001 100644
          this.callParent(arguments);
          this.getController().setVersionFilter(values.machine);
          this.getController().setArch(values.arch);
-diff --git a/www/manager6/qemu/QemuArchEdit.js b/www/manager6/qemu/QemuArchEdit.js
+diff --git c/www/manager6/qemu/QemuArchEdit.js i/www/manager6/qemu/QemuArchEdit.js
 new file mode 100644
-index 00000000..caa9d6a7
+index 000000000..caa9d6a7b
 --- /dev/null
-+++ b/www/manager6/qemu/QemuArchEdit.js
++++ i/www/manager6/qemu/QemuArchEdit.js
 @@ -0,0 +1,26 @@
 +Ext.define('PVE.qemu.QemuArchEdit', {
 +    extend: 'Proxmox.window.Edit',
@@ -584,3 +1014,39 @@ index 00000000..caa9d6a7
 +        },
 +    ],
 +});
+diff --git c/www/manager6/storage/Browser.js i/www/manager6/storage/Browser.js
+index d02379487..dcf983d28 100644
+--- c/www/manager6/storage/Browser.js
++++ i/www/manager6/storage/Browser.js
+@@ -107,6 +107,19 @@ Ext.define('PVE.storage.Browser', {
+                     useUploadButton: true,
+                 });
+             }
++            if (contents.includes('floppy')) {
++                me.items.push({
++                    xtype: 'pveStorageContentView',
++                    title: gettext('Floppy Images'),
++                    iconCls: 'fa fa-floppy-o',
++                    itemId: 'contentFloppy',
++                    content: 'floppy',
++                    pluginType: plugin,
++                    enableUploadButton: enableUpload,
++                    enableDownloadUrlButton: enableDownloadUrl,
++                    useUploadButton: true,
++                });
++            }
+             if (contents.includes('vztmpl')) {
+                 me.items.push({
+                     xtype: 'pveStorageTemplateView',
+diff --git c/www/manager6/window/UploadToStorage.js i/www/manager6/window/UploadToStorage.js
+index cc53596d8..3132c1e15 100644
+--- c/www/manager6/window/UploadToStorage.js
++++ i/www/manager6/window/UploadToStorage.js
+@@ -11,6 +11,7 @@ Ext.define('PVE.window.UploadToStorage', {
+     acceptedExtensions: {
+         import: ['.ova', '.qcow2', '.raw', '.vmdk'],
+         iso: ['.img', '.iso'],
++        floppy: ['.img', '.ima', '.vfd'],
+         vztmpl: ['.tar.gz', '.tar.xz', '.tar.zst'],
+     },
+ 

--- a/submodules/pve-storage.Dockerfile
+++ b/submodules/pve-storage.Dockerfile
@@ -1,0 +1,9 @@
+FROM scratch AS build
+COPY /build/repo /build/repo
+
+FROM scratch AS final
+ARG IMAGE_DESCRIPTION="Proxmox VE Storage + wsh patch"
+LABEL org.opencontainers.image.title="pve-storage+wsh"
+LABEL org.opencontainers.image.description="$IMAGE_DESCRIPTION"
+COPY --from=build /build/repo/libpve-storage-perl_*.deb /opt/repo/
+CMD ["bash"]

--- a/submodules/pve-storage.patch
+++ b/submodules/pve-storage.patch
@@ -1,0 +1,358 @@
+diff --git c/src/PVE/API2/Storage/Status.pm i/src/PVE/API2/Storage/Status.pm
+index 741d514..17b9180 100644
+--- c/src/PVE/API2/Storage/Status.pm
++++ i/src/PVE/API2/Storage/Status.pm
+@@ -533,7 +533,7 @@ __PACKAGE__->register_method({
+                 description => "Content type.",
+                 type => 'string',
+                 format => 'pve-storage-content',
+-                enum => ['iso', 'vztmpl', 'import'],
++                enum => ['iso', 'vztmpl', 'import', 'floppy'],
+             },
+             filename => {
+                 description =>
+@@ -598,6 +598,11 @@ __PACKAGE__->register_method({
+                 raise_param_exc({ filename => "wrong file extension" });
+             }
+             $path = PVE::Storage::get_iso_dir($cfg, $storage);
++        } elsif ($content eq 'floppy') {
++            if ($filename !~ m![^/]+$PVE::Storage::FLOPPY_EXT_RE_0$!) {
++                raise_param_exc({ filename => "wrong file extension" });
++            }
++            $path = PVE::Storage::get_floppy_dir($cfg, $storage);
+         } elsif ($content eq 'vztmpl') {
+             if ($filename !~ m![^/]+$PVE::Storage::VZTMPL_EXT_RE_1$!) {
+                 raise_param_exc({ filename => "wrong file extension" });
+@@ -770,7 +775,7 @@ __PACKAGE__->register_method({
+                 description => "Content type.", # TODO: could be optional & detected in most cases
+                 type => 'string',
+                 format => 'pve-storage-content',
+-                enum => ['iso', 'vztmpl', 'import'],
++                enum => ['iso', 'vztmpl', 'import', 'floppy'],
+             },
+             filename => {
+                 description =>
+@@ -839,6 +844,11 @@ __PACKAGE__->register_method({
+                 raise_param_exc({ filename => "wrong file extension" });
+             }
+             $path = PVE::Storage::get_iso_dir($cfg, $storage);
++        } elsif ($content eq 'floppy') {
++            if ($filename !~ m![^/]+$PVE::Storage::FLOPPY_EXT_RE_0$!) {
++                raise_param_exc({ filename => "wrong file extension" });
++            }
++            $path = PVE::Storage::get_floppy_dir($cfg, $storage);
+         } elsif ($content eq 'vztmpl') {
+             if ($filename !~ m![^/]+$PVE::Storage::VZTMPL_EXT_RE_1$!) {
+                 raise_param_exc({ filename => "wrong file extension" });
+diff --git c/src/PVE/Storage.pm i/src/PVE/Storage.pm
+index 64ea9da..8bc3a8a 100755
+--- c/src/PVE/Storage.pm
++++ i/src/PVE/Storage.pm
+@@ -115,6 +115,8 @@ PVE::Storage::Plugin->init();
+ 
+ our $ISO_EXT_RE_0 = qr/\.(?:iso|img)/i;
+ 
++our $FLOPPY_EXT_RE_0 = qr/\.(?:img|ima|vfd)/i;
++
+ our $VZTMPL_EXT_RE_1 = qr/\.(?|(tar)(?!\.)|tar\.(gz|xz|zst|bz2))/i;
+ 
+ our $BACKUP_EXT_RE_2 = qr/\.(tgz|(?:tar|vma)(?:\.(${\PVE::Storage::Plugin::COMPRESSOR_RE}))?)/;
+@@ -564,6 +566,15 @@ sub get_import_dir {
+     return $plugin->get_subdir($scfg, 'import');
+ }
+ 
++sub get_floppy_dir {
++    my ($cfg, $storeid) = @_;
++
++    my $scfg = storage_config($cfg, $storeid);
++    my $plugin = PVE::Storage::Plugin->lookup($scfg->{type});
++
++    return $plugin->get_subdir($scfg, 'floppy');
++}
++
+ sub get_vztmpl_dir {
+     my ($cfg, $storeid) = @_;
+ 
+@@ -629,7 +640,7 @@ sub check_volume_access {
+ 
+         return if $rpcenv->check($user, "/storage/$sid", ['Datastore.Allocate'], 1);
+ 
+-        if ($vtype eq 'iso' || $vtype eq 'vztmpl' || $vtype eq 'import') {
++        if ($vtype eq 'iso' || $vtype eq 'vztmpl' || $vtype eq 'import' || $vtype eq 'floppy') {
+             # require at least read access to storage, (custom) templates/ISOs could be sensitive
+             $rpcenv->check_any(
+                 $user,
+@@ -715,6 +726,7 @@ sub path_to_volume_id {
+         my $plugin = PVE::Storage::Plugin->lookup($scfg->{type});
+         my $imagedir = $plugin->get_subdir($scfg, 'images');
+         my $isodir = $plugin->get_subdir($scfg, 'iso');
++        my $floppydir = $plugin->get_subdir($scfg, 'floppy');
+         my $tmpldir = $plugin->get_subdir($scfg, 'vztmpl');
+         my $backupdir = $plugin->get_subdir($scfg, 'backup');
+         my $snippetsdir = $plugin->get_subdir($scfg, 'snippets');
+@@ -735,6 +747,9 @@ sub path_to_volume_id {
+         } elsif ($path =~ m!^\Q$isodir\E/([^/]+$ISO_EXT_RE_0)$!) {
+             my $name = $1;
+             return ('iso', "$sid:iso/$name");
++        } elsif ($path =~ m!^\Q$floppydir\E/([^/]+$FLOPPY_EXT_RE_0)$!) {
++            my $name = $1;
++            return ('floppy', "$sid:floppy/$name");
+         } elsif ($path =~ m!^\Q$tmpldir\E/([^/]+$VZTMPL_EXT_RE_1)$!) {
+             my $name = $1;
+             return ('vztmpl', "$sid:vztmpl/$name");
+@@ -799,7 +814,7 @@ sub qemu_blockdev_options {
+ 
+     my ($vtype) = $plugin->parse_volname($volname);
+     die "cannot use volume of type '$vtype' as a QEMU blockdevice\n"
+-        if $vtype ne 'images' && $vtype ne 'iso' && $vtype ne 'import';
++        if $vtype ne 'images' && $vtype ne 'iso' && $vtype ne 'import' && $vtype ne 'floppy';
+ 
+     my $blockdev =
+         $plugin->qemu_blockdev_options($scfg, $storeid, $volname, $machine_version, $options);
+@@ -1269,7 +1284,11 @@ sub template_list {
+     my ($cfg, $storeid, $tt) = @_;
+ 
+     die "unknown template type '$tt'\n"
+-        if !($tt eq 'iso' || $tt eq 'vztmpl' || $tt eq 'backup' || $tt eq 'snippets');
++        if !($tt eq 'iso'
++            || $tt eq 'vztmpl'
++            || $tt eq 'backup'
++            || $tt eq 'snippets'
++            || $tt eq 'floppy');
+ 
+     my $ids = $cfg->{ids};
+ 
+@@ -1297,7 +1316,7 @@ sub template_list {
+ sub volume_list {
+     my ($cfg, $storeid, $vmid, $content) = @_;
+ 
+-    my @ctypes = qw(rootdir images vztmpl iso backup snippets import);
++    my @ctypes = qw(rootdir images vztmpl iso backup snippets import floppy);
+ 
+     my $cts = $content ? [$content] : [@ctypes];
+ 
+@@ -2281,7 +2300,7 @@ sub complete_storage_enabled {
+ sub complete_content_type {
+     my ($cmdname, $pname, $cvalue) = @_;
+ 
+-    return [qw(rootdir images vztmpl iso backup snippets)];
++    return [qw(rootdir images vztmpl iso backup snippets floppy)];
+ }
+ 
+ sub complete_volume {
+diff --git c/src/PVE/Storage/BTRFSPlugin.pm i/src/PVE/Storage/BTRFSPlugin.pm
+index fb47aa0..55535f0 100644
+--- c/src/PVE/Storage/BTRFSPlugin.pm
++++ i/src/PVE/Storage/BTRFSPlugin.pm
+@@ -37,6 +37,7 @@ sub plugindata {
+                 rootdir => 1,
+                 vztmpl => 1,
+                 iso => 1,
++                floppy => 1,
+                 backup => 1,
+                 snippets => 1,
+                 none => 1,
+diff --git c/src/PVE/Storage/CIFSPlugin.pm i/src/PVE/Storage/CIFSPlugin.pm
+index 54f0f4e..a5fd314 100644
+--- c/src/PVE/Storage/CIFSPlugin.pm
++++ i/src/PVE/Storage/CIFSPlugin.pm
+@@ -118,6 +118,7 @@ sub plugindata {
+                 rootdir => 1,
+                 vztmpl => 1,
+                 iso => 1,
++                floppy => 1,
+                 backup => 1,
+                 snippets => 1,
+                 import => 1,
+diff --git c/src/PVE/Storage/CephFSPlugin.pm i/src/PVE/Storage/CephFSPlugin.pm
+index fbc9711..aa6dc02 100644
+--- c/src/PVE/Storage/CephFSPlugin.pm
++++ i/src/PVE/Storage/CephFSPlugin.pm
+@@ -116,8 +116,10 @@ sub type {
+ 
+ sub plugindata {
+     return {
+-        content =>
+-            [{ vztmpl => 1, iso => 1, backup => 1, snippets => 1, import => 1 }, { backup => 1 }],
++        content => [
++            { vztmpl => 1, iso => 1, floppy => 1, backup => 1, snippets => 1, import => 1 },
++            { backup => 1 },
++        ],
+         'sensitive-properties' => { keyring => 1 },
+     };
+ }
+diff --git c/src/PVE/Storage/DirPlugin.pm i/src/PVE/Storage/DirPlugin.pm
+index 80c4a03..30d3fd3 100644
+--- c/src/PVE/Storage/DirPlugin.pm
++++ i/src/PVE/Storage/DirPlugin.pm
+@@ -30,6 +30,7 @@ sub plugindata {
+                 rootdir => 1,
+                 vztmpl => 1,
+                 iso => 1,
++                floppy => 1,
+                 backup => 1,
+                 snippets => 1,
+                 none => 1,
+diff --git c/src/PVE/Storage/NFSPlugin.pm i/src/PVE/Storage/NFSPlugin.pm
+index 4cc02c9..4893b53 100644
+--- c/src/PVE/Storage/NFSPlugin.pm
++++ i/src/PVE/Storage/NFSPlugin.pm
+@@ -59,6 +59,7 @@ sub plugindata {
+                 rootdir => 1,
+                 vztmpl => 1,
+                 iso => 1,
++                floppy => 1,
+                 backup => 1,
+                 snippets => 1,
+                 import => 1,
+diff --git c/src/PVE/Storage/Plugin.pm i/src/PVE/Storage/Plugin.pm
+index 4f69f9b..30007d7 100644
+--- c/src/PVE/Storage/Plugin.pm
++++ i/src/PVE/Storage/Plugin.pm
+@@ -811,6 +811,8 @@ sub parse_volname {
+         return ('images', $name, $vmid, undef, undef, $isBase, $format);
+     } elsif ($volname =~ m!^iso/([^/]+$PVE::Storage::ISO_EXT_RE_0)$!) {
+         return ('iso', $1, undef, undef, undef, undef, 'raw');
++    } elsif ($volname =~ m!^floppy/([^/]+$PVE::Storage::FLOPPY_EXT_RE_0)$!) {
++        return ('floppy', $1, undef, undef, undef, undef, 'raw');
+     } elsif ($volname =~ m!^vztmpl/([^/]+$PVE::Storage::VZTMPL_EXT_RE_1)$!) {
+         return ('vztmpl', $1, undef, undef, undef, undef, 'raw');
+     } elsif ($volname =~ m!^backup/([^/]+$PVE::Storage::BACKUP_EXT_RE_2)$!) {
+@@ -840,6 +842,7 @@ my $vtype_subdirs = {
+     images => 'images',
+     rootdir => 'private',
+     iso => 'template/iso',
++    floppy => 'template/floppy',
+     vztmpl => 'template/cache',
+     backup => 'dump',
+     snippets => 'snippets',
+@@ -1708,6 +1711,11 @@ my $get_subdir_files = sub {
+ 
+             $info = { volid => "$sid:iso/$1", format => 'iso' };
+ 
++        } elsif ($tt eq 'floppy') {
++            next if $fn !~ m!/([^/]+$PVE::Storage::FLOPPY_EXT_RE_0)$!i;
++
++            $info = { volid => "$sid:floppy/$1", format => 'raw' };
++
+         } elsif ($tt eq 'vztmpl') {
+             next if $fn !~ m!/([^/]+$PVE::Storage::VZTMPL_EXT_RE_1)$!;
+ 
+@@ -1781,6 +1789,8 @@ sub list_volumes {
+ 
+             if ($type eq 'iso' && !defined($vmid)) {
+                 $data = $get_subdir_files->($storeid, $path, 'iso');
++            } elsif ($type eq 'floppy' && !defined($vmid)) {
++                $data = $get_subdir_files->($storeid, $path, 'floppy');
+             } elsif ($type eq 'vztmpl' && !defined($vmid)) {
+                 $data = $get_subdir_files->($storeid, $path, 'vztmpl');
+             } elsif ($type eq 'backup') {
+@@ -2253,7 +2263,7 @@ sub volume_export_formats {
+             return ();
+         }
+         return ('tar+size') if $format eq 'subvol';
+-        return ('raw+size') if $vtype =~ /^(images|iso|snippets|vztmpl|import)$/;
++        return ('raw+size') if $vtype =~ /^(images|iso|snippets|vztmpl|import|floppy)$/;
+     }
+     return ();
+ }
+@@ -2338,7 +2348,7 @@ sub volume_import {
+             warn $@ if $@;
+             die $err;
+         }
+-    } elsif (grep { $vtype eq $_ } qw(import iso snippets vztmpl)) {
++    } elsif (grep { $vtype eq $_ } qw(import iso snippets vztmpl floppy)) {
+         eval {
+             run_command(['dd', "of=$file", 'conv=excl', 'bs=64k'], input => '<&' . fileno($fh));
+         };
+@@ -2366,7 +2376,7 @@ sub volume_import_formats {
+             return ();
+         }
+         return ('tar+size') if $format eq 'subvol';
+-        return ('raw+size') if $vtype =~ /^(images|iso|snippets|vztmpl|import)$/;
++        return ('raw+size') if $vtype =~ /^(images|iso|snippets|vztmpl|import|floppy)$/;
+     }
+     return ();
+ }
+diff --git c/src/test/parse_volname_test.pm i/src/test/parse_volname_test.pm
+index 5c9478a..8f61e24 100644
+--- c/src/test/parse_volname_test.pm
++++ i/src/test/parse_volname_test.pm
+@@ -46,6 +46,24 @@ my $tests = [
+             ['iso', 'some-other-installation-disk.img', undef, undef, undef, undef, 'raw'],
+     },
+     #
++    # floppy
++    #
++    {
++        description => 'Floppy image, img',
++        volname => 'floppy/dos-boot-disk.img',
++        expected => ['floppy', 'dos-boot-disk.img', undef, undef, undef, undef, 'raw'],
++    },
++    {
++        description => 'Floppy image, ima',
++        volname => 'floppy/dos-boot-disk.ima',
++        expected => ['floppy', 'dos-boot-disk.ima', undef, undef, undef, undef, 'raw'],
++    },
++    {
++        description => 'Floppy image, vfd',
++        volname => 'floppy/win98-drivers.vfd',
++        expected => ['floppy', 'win98-drivers.vfd', undef, undef, undef, undef, 'raw'],
++    },
++    #
+     # container templates
+     #
+     {
+diff --git c/src/test/path_to_volume_id_test.pm i/src/test/path_to_volume_id_test.pm
+index dfa51e6..f49983b 100644
+--- c/src/test/path_to_volume_id_test.pm
++++ i/src/test/path_to_volume_id_test.pm
+@@ -27,6 +27,7 @@ my $scfg = {
+                 'rootdir' => 1,
+                 'images' => 1,
+                 'iso' => 1,
++                'floppy' => 1,
+                 'backup' => 1,
+                 'vztmpl' => 1,
+             },
+@@ -121,6 +122,13 @@ my @tests = (
+             'iso', 'local:iso/yet-again-a-installation-disk.iso',
+         ],
+     },
++    {
++        description => 'Floppy file',
++        volname => "$storage_dir/template/floppy/dos-boot-disk.img",
++        expected => [
++            'floppy', 'local:floppy/dos-boot-disk.img',
++        ],
++    },
+     {
+         description => 'CT template, tar.gz',
+         volname => "$storage_dir/template/cache/debian-10.0-standard_10.0-1_amd64.tar.gz",
+diff --git c/src/test/run_volume_access_tests.pl i/src/test/run_volume_access_tests.pl
+index 3448708..f4a5772 100755
+--- c/src/test/run_volume_access_tests.pl
++++ i/src/test/run_volume_access_tests.pl
+@@ -15,7 +15,7 @@ use PVE::Storage::Plugin;
+ my $storage_cfg = <<'EOF';
+ dir: dir
+ 	path /mnt/pve/dir
+-	content vztmpl,snippets,iso,backup,rootdir,images
++	content vztmpl,snippets,iso,floppy,backup,rootdir,images
+ EOF
+ 
+ my $user_cfg = <<'EOF';
+@@ -103,6 +103,13 @@ my @tests = (
+             'iso' => 1,
+         },
+     },
++    {
++        volid => 'dir:floppy/dos-boot-disk.img',
++        denied_users => {},
++        allowed_types => {
++            'floppy' => 1,
++        },
++    },
+     {
+         volid => 'dir:111/subvol-111-disk-0.subvol',
+         denied_users => {

--- a/submodules/qemu-server.patch
+++ b/submodules/qemu-server.patch
@@ -1,8 +1,45 @@
-diff --git a/src/PVE/QemuServer.pm b/src/PVE/QemuServer.pm
-index cdf66e89..838d69e3 100644
---- a/src/PVE/QemuServer.pm
-+++ b/src/PVE/QemuServer.pm
-@@ -167,7 +167,7 @@ my $vga_fmt = {
+diff --git c/src/PVE/API2/Qemu.pm i/src/PVE/API2/Qemu.pm
+index 28cbb9b0..f78e8293 100644
+--- c/src/PVE/API2/Qemu.pm
++++ i/src/PVE/API2/Qemu.pm
+@@ -152,6 +152,8 @@ my $check_drive_param = sub {
+             my $vtype = (PVE::Storage::parse_volname($storecfg, $volid))[0];
+             raise_param_exc({ $opt => "explicit 'media=cdrom' is required for iso images" })
+                 if $vtype eq 'iso' && !(defined($drive->{media}) && $drive->{media} eq 'cdrom');
++            raise_param_exc({ $opt => "floppy images can only be attached to floppy drives" })
++                if $vtype eq 'floppy' && $opt !~ m/^floppy\d+$/;
+         }
+ 
+         $extra_checks->($drive) if $extra_checks;
+@@ -194,8 +196,9 @@ my $check_storage_access = sub {
+                 PVE::Storage::check_volume_access($rpcenv, $authuser, $storecfg, $vmid, $volid);
+                 if ($storeid) {
+                     my ($vtype) = PVE::Storage::parse_volname($storecfg, $volid);
+-                    raise_param_exc({ $ds => "content type needs to be 'images' or 'iso'" })
+-                        if $vtype ne 'images' && $vtype ne 'iso';
++                    raise_param_exc(
++                        { $ds => "content type needs to be 'images', 'iso' or 'floppy'" })
++                        if $vtype ne 'images' && $vtype ne 'iso' && $vtype ne 'floppy';
+                 }
+             }
+ 
+@@ -661,8 +664,9 @@ my sub create_disks : prototype($$$$$$$$$$$) {
+             if ($storeid) {
+                 my ($vtype, $volume_format) = (checked_parse_volname($storecfg, $volid))[0, 6];
+ 
+-                die "cannot use volume $volid - content type needs to be 'images' or 'iso'"
+-                    if $vtype ne 'images' && $vtype ne 'iso';
++                die "cannot use volume $volid - content type needs to be 'images', 'iso'"
++                    . " or 'floppy'"
++                    if $vtype ne 'images' && $vtype ne 'iso' && $vtype ne 'floppy';
+ 
+                 # TODO PVE 9 - consider disallowing setting an explicit format for managed volumes.
+                 if ($disk->{format} && $disk->{format} ne $volume_format) {
+diff --git c/src/PVE/QemuServer.pm i/src/PVE/QemuServer.pm
+index 9aec7f9c..2294041b 100644
+--- c/src/PVE/QemuServer.pm
++++ i/src/PVE/QemuServer.pm
+@@ -168,7 +168,7 @@ my $vga_fmt = {
          optional => 1,
          default_key => 1,
          enum => [
@@ -11,7 +48,7 @@ index cdf66e89..838d69e3 100644
          ],
      },
      memory => {
-@@ -186,6 +186,20 @@ my $vga_fmt = {
+@@ -187,6 +187,20 @@ my $vga_fmt = {
          enum => ['vnc'],
          optional => 1,
      },
@@ -32,7 +69,7 @@ index cdf66e89..838d69e3 100644
  };
  
  my $ivshmem_fmt = {
-@@ -207,16 +221,30 @@ my $ivshmem_fmt = {
+@@ -208,16 +222,30 @@ my $ivshmem_fmt = {
  my $audio_fmt = {
      device => {
          type => 'string',
@@ -65,7 +102,7 @@ index cdf66e89..838d69e3 100644
  };
  
  my $spice_enhancements_fmt = {
-@@ -658,7 +686,7 @@ EODESCR
+@@ -659,7 +687,7 @@ EODESCR
      bios => {
          optional => 1,
          type => 'string',
@@ -74,7 +111,28 @@ index cdf66e89..838d69e3 100644
          description => "Select BIOS implementation.",
          default => 'seabios',
      },
-@@ -2789,6 +2817,7 @@ sub conf_has_audio {
+@@ -1227,6 +1255,8 @@ sub print_drive_commandline_full {
+     my $opts = '';
+     my @qemu_drive_options = qw(media cache rerror werror discard);
+     foreach my $o (@qemu_drive_options) {
++        # QEMU's -drive media option only knows disk|cdrom
++        next if $o eq 'media' && PVE::QemuServer::Drive::drive_is_floppy($drive);
+         $opts .= ",$o=$drive->{$o}" if defined($drive->{$o});
+     }
+ 
+@@ -1281,6 +1311,11 @@ sub print_drive_commandline_full {
+     die "$drive_id: explicit media parameter is required for iso images\n"
+         if !defined($drive->{media}) && defined($vtype) && $vtype eq 'iso';
+ 
++    die "$drive_id: floppy images can only be used with floppy drives\n"
++        if defined($vtype)
++        && $vtype eq 'floppy'
++        && !PVE::QemuServer::Drive::drive_is_floppy($drive);
++
+     if (!drive_is_cdrom($drive)) {
+         my $detectzeroes = PVE::QemuServer::Drive::detect_zeroes_cmdline_option($drive);
+ 
+@@ -2802,6 +2837,7 @@ sub conf_has_audio {
          dev_id => "audiodev$id",
          backend => $audiodriver,
          backend_id => "$audiodriver-backend${id}",
@@ -82,7 +140,7 @@ index cdf66e89..838d69e3 100644
      };
  }
  
-@@ -2805,6 +2834,20 @@ sub audio_devs {
+@@ -2818,6 +2854,20 @@ sub audio_devs {
  
      if ($audio->{dev} eq 'AC97') {
          push @$devs, '-device', "AC97,id=${id}${audiopciaddr}$audiodev";
@@ -103,7 +161,7 @@ index cdf66e89..838d69e3 100644
      } elsif ($audio->{dev} =~ /intel\-hda$/) {
          push @$devs, '-device', "$audio->{dev},id=${id}${audiopciaddr}";
          push @$devs, '-device', "hda-micro,id=${id}-codec0,bus=${id}.0,cad=0$audiodev";
-@@ -2813,7 +2856,20 @@ sub audio_devs {
+@@ -2826,7 +2876,20 @@ sub audio_devs {
          die "unknown audio device '$audio->{dev}', implement me!";
      }
  
@@ -125,7 +183,7 @@ index cdf66e89..838d69e3 100644
  
      return $devs;
  }
-@@ -2953,7 +3009,7 @@ sub vga_conf_has_spice {
+@@ -2966,7 +3029,7 @@ sub vga_conf_has_spice {
  # since kvm and tcg machines support different flags
  #
  sub query_supported_cpu_flags {
@@ -134,7 +192,7 @@ index cdf66e89..838d69e3 100644
  
      my $host_arch = get_host_arch();
      $arch //= $host_arch;
-@@ -2962,7 +3018,7 @@ sub query_supported_cpu_flags {
+@@ -2975,7 +3038,7 @@ sub query_supported_cpu_flags {
      my $flags = {};
  
      my $kvm_supported = defined(kvm_version()) && $arch eq $host_arch;
@@ -143,7 +201,7 @@ index cdf66e89..838d69e3 100644
      my $fakevmid = -1;
      my $pidfile = PVE::QemuServer::Helpers::vm_pidfile_name($fakevmid);
  
-@@ -3047,7 +3103,7 @@ sub query_supported_cpu_flags {
+@@ -3060,7 +3123,7 @@ sub query_supported_cpu_flags {
  my sub should_disable_smm {
      my ($conf, $vga, $machine) = @_;
  
@@ -152,7 +210,7 @@ index cdf66e89..838d69e3 100644
  
      return
          (!defined($conf->{bios}) || $conf->{bios} eq 'seabios')
-@@ -3120,7 +3176,7 @@ sub config_to_command {
+@@ -3133,7 +3196,7 @@ sub config_to_command {
      my $machine_conf = PVE::QemuServer::Machine::parse_machine($conf->{machine});
  
      my $arch = PVE::QemuServer::Helpers::get_vm_arch($conf);
@@ -161,7 +219,7 @@ index cdf66e89..838d69e3 100644
      my $kvmver = kvm_user_version($kvm_binary);
  
      if (!$kvmver || $kvmver !~ m/^(\d+)\.(\d+)/ || $1 < 6) {
-@@ -3226,7 +3282,9 @@ sub config_to_command {
+@@ -3239,7 +3302,9 @@ sub config_to_command {
              $value =~ s/,/,,/g;
              $smbios_string .= "," . $key . "=" . $value if $value;
          }
@@ -172,7 +230,7 @@ index cdf66e89..838d69e3 100644
      }
  
      if ($conf->{bios} && $conf->{bios} eq 'ovmf') {
-@@ -3246,6 +3304,10 @@ sub config_to_command {
+@@ -3259,6 +3324,10 @@ sub config_to_command {
          push $machineFlags->@*, $ovmf_machine_flags->@*;
      }
  
@@ -183,7 +241,7 @@ index cdf66e89..838d69e3 100644
      if ($q35) { # tell QEMU to load q35 config early
          # we use different pcie-port hardware for qemu >= 4.0 for passthrough
          if (min_version($machine_version, 4, 0)) {
-@@ -3264,9 +3326,11 @@ sub config_to_command {
+@@ -3277,9 +3346,11 @@ sub config_to_command {
      }
  
      # add usb controllers
@@ -195,7 +253,7 @@ index cdf66e89..838d69e3 100644
  
      my ($vga, $qxlnum) = get_vga_properties($conf, $arch, $machine_version, $winversion);
  
-@@ -3285,7 +3349,6 @@ sub config_to_command {
+@@ -3298,7 +3369,6 @@ sub config_to_command {
      }
  
      my $bootorder = device_bootorder($conf);
@@ -203,7 +261,7 @@ index cdf66e89..838d69e3 100644
      # host pci device passthrough
      my ($kvm_off, $gpu_passthrough, $legacy_igd, $pci_devices) =
          PVE::QemuServer::PCI::print_hostpci_devices(
-@@ -3376,9 +3439,27 @@ sub config_to_command {
+@@ -3389,9 +3459,27 @@ sub config_to_command {
  
      push @$cmd, '-no-reboot' if defined($conf->{reboot}) && $conf->{reboot} == 0;
  
@@ -232,7 +290,7 @@ index cdf66e89..838d69e3 100644
  
          push @$cmd, '-display', 'egl-headless,gl=core' if $vga->{type} eq 'virtio-gl'; # VIRGL
  
-@@ -3397,6 +3478,7 @@ sub config_to_command {
+@@ -3410,6 +3498,7 @@ sub config_to_command {
      push $machineFlags->@*, ($generated->machine_flags() // [])->@*;
      push $rtcFlags->@*, ($generated->rtc_flags() // [])->@*;
  
@@ -240,7 +298,7 @@ index cdf66e89..838d69e3 100644
      if ($forcecpu) {
          push @$cmd, '-cpu', $forcecpu;
      } else {
-@@ -3412,6 +3494,7 @@ sub config_to_command {
+@@ -3425,6 +3514,7 @@ sub config_to_command {
                  $kvmver,
              );
      }
@@ -248,7 +306,15 @@ index cdf66e89..838d69e3 100644
  
      my $virtiofs_enabled = PVE::QemuServer::Virtiofs::virtiofs_enabled($conf);
  
-@@ -3595,9 +3678,11 @@ sub config_to_command {
+@@ -3547,6 +3637,7 @@ sub config_to_command {
+ 
+     my $scsicontroller = {};
+     my $ahcicontroller = {};
++    my $fdccontroller = 0;
+     my $scsihw = defined($conf->{scsihw}) ? $conf->{scsihw} : $defaults->{scsihw};
+ 
+     # Add iscsi initiator name if available
+@@ -3608,9 +3699,11 @@ sub config_to_command {
                      $queues = ",num_queues=$drive->{queues}";
                  }
  
@@ -261,7 +327,21 @@ index cdf66e89..838d69e3 100644
                  $scsicontroller->{$controller} = 1;
              }
  
-@@ -3669,7 +3754,12 @@ sub config_to_command {
+@@ -3622,6 +3715,13 @@ sub config_to_command {
+                 $ahcicontroller->{$controller} = 1;
+             }
+ 
++            if ($drive->{interface} eq 'floppy') {
++                die "floppy drives are only supported on x86_64\n" if $arch ne 'x86_64';
++                # i440fx has an onboard floppy controller, q35 does not
++                push @$devices, '-device', 'isa-fdc,id=fdc' if $q35 && !$fdccontroller;
++                $fdccontroller = 1;
++            }
++
+             my $live_restore = $live_restore_backing->{$ds};
+ 
+             if (min_version($machine_version, 10, 0)) { # for the switch to -blockdev
+@@ -3682,7 +3782,12 @@ sub config_to_command {
          $d->{bootindex} = $bootorder->{$netname} if $bootorder->{$netname};
  
          my $netdevfull = print_netdev_full($vmid, $conf, $arch, $d, $netname);
@@ -275,7 +355,7 @@ index cdf66e89..838d69e3 100644
  
          # force +pve1 if machine version 10.0, for host_mtu differentiation
          $version_guard->(10, 0, 1);
-@@ -3685,7 +3775,17 @@ sub config_to_command {
+@@ -3698,7 +3803,17 @@ sub config_to_command {
              $nets_host_mtu->{$netname},
          );
  
@@ -294,7 +374,7 @@ index cdf66e89..838d69e3 100644
      }
  
      if ($conf->{ivshmem}) {
-@@ -3709,7 +3809,7 @@ sub config_to_command {
+@@ -3722,7 +3837,7 @@ sub config_to_command {
      # pci.4 is nested in pci.1
      $bridges->{1} = 1 if $bridges->{4};
  
@@ -303,7 +383,39 @@ index cdf66e89..838d69e3 100644
          if (min_version($machine_version, 2, 3)) {
              $bridges->{1} = 1;
              $bridges->{2} = 1;
-@@ -5792,6 +5892,9 @@ sub vm_start_nolock {
+@@ -4757,7 +4872,8 @@ sub vmconfig_hotplug_pending {
+                 );
+             } elsif (is_valid_drivename($opt)) {
+                 die "skip\n"
+-                    if !$hotplug_features->{disk} || $opt =~ m/(efidisk|ide|sata|tpmstate)(\d+)/;
++                    if !$hotplug_features->{disk}
++                    || $opt =~ m/(efidisk|ide|sata|tpmstate|floppy)(\d+)/;
+                 vm_deviceunplug($vmid, $conf, $opt);
+                 vmconfig_delete_or_detach_drive($vmid, $storecfg, $conf, $opt, $force);
+             } elsif ($opt =~ m/^memory$/) {
+@@ -5216,8 +5332,10 @@ sub vmconfig_update_disk {
+     my $drive = parse_drive($opt, $value);
+ 
+     if ($conf->{$opt} && (my $old_drive = parse_drive($opt, $conf->{$opt}))) {
+-        my $media = $drive->{media} || 'disk';
+-        my $oldmedia = $old_drive->{media} || 'disk';
++        my $default_media =
++            PVE::QemuServer::Drive::drive_is_floppy($drive) ? 'floppy' : 'disk';
++        my $media = $drive->{media} || $default_media;
++        my $oldmedia = $old_drive->{media} || $default_media;
+         die "unable to change media type\n" if $media ne $oldmedia;
+ 
+         if (!drive_is_cdrom($old_drive)) {
+@@ -5314,7 +5432,7 @@ sub vmconfig_update_disk {
+         }
+     }
+ 
+-    die "skip\n" if !$hotplug || $opt =~ m/(ide|sata)(\d+)/;
++    die "skip\n" if !$hotplug || $opt =~ m/(ide|sata|floppy)(\d+)/;
+     # hotplug new disks
+     PVE::Storage::activate_volumes($storecfg, [$drive->{file}]) if $drive->{file} !~ m|^/dev/.+|;
+     vm_deviceplug($storecfg, $conf, $vmid, $opt, $drive, $arch, $machine_type);
+@@ -5805,6 +5923,9 @@ sub vm_start_nolock {
                  }
              }
  
@@ -313,23 +425,182 @@ index cdf66e89..838d69e3 100644
              my $exitcode = run_command($cmd, %run_params);
              eval { PVE::QemuServer::Virtiofs::close_sockets(@$virtiofs_sockets); };
              log_warn("closing virtiofs sockets failed - $@") if $@;
-diff --git a/src/PVE/QemuServer/Drive.pm b/src/PVE/QemuServer/Drive.pm
-index b80b7dbb..afc4f2ef 100644
---- a/src/PVE/QemuServer/Drive.pm
-+++ b/src/PVE/QemuServer/Drive.pm
-@@ -847,7 +847,7 @@ sub parse_drive {
+@@ -8206,7 +8327,12 @@ sub bootorder_from_legacy {
+         sub {
+             my ($ds, $drive) = @_;
+ 
+-            if (drive_is_cdrom($drive, 1)) {
++            if (PVE::QemuServer::Drive::drive_is_floppy($drive)) {
++                if ($bootindex_hash->{a}) {
++                    $bootorder->{$ds} = $bootindex_hash->{a};
++                    $bootindex_hash->{a} += 1;
++                }
++            } elsif (drive_is_cdrom($drive, 1)) {
+                 if ($bootindex_hash->{d}) {
+                     $bootorder->{$ds} = $bootindex_hash->{d};
+                     $bootindex_hash->{d} += 1;
+diff --git c/src/PVE/QemuServer/Blockdev.pm i/src/PVE/QemuServer/Blockdev.pm
+index 101c747c..b268f7ee 100644
+--- c/src/PVE/QemuServer/Blockdev.pm
++++ i/src/PVE/QemuServer/Blockdev.pm
+@@ -202,6 +202,10 @@ sub get_node_name_below_throttle {
+ my sub read_only_json_option {
+     my ($drive, $options) = @_;
+ 
++    # floppies are removable media like cdroms, but writable unless ro is set
++    return json_bool($drive->{ro} || $options->{'read-only'})
++        if PVE::QemuServer::Drive::drive_is_floppy($drive);
++
+     return json_bool($drive->{ro} || drive_is_cdrom($drive) || $options->{'read-only'});
+ }
+ 
+@@ -307,7 +311,10 @@ sub generate_file_blockdev {
+         my $st = File::stat::stat($path) or die "stat for '$path' failed - $!\n";
+         my $driver = 'file';
+         if (S_ISCHR($st->mode) || S_ISBLK($st->mode)) {
+-            $driver = drive_is_cdrom($drive) ? 'host_cdrom' : 'host_device';
++            $driver =
++                (drive_is_cdrom($drive) && !PVE::QemuServer::Drive::drive_is_floppy($drive))
++                ? 'host_cdrom'
++                : 'host_device';
+         }
+         $blockdev = { driver => "$driver", filename => "$path" };
+     } else {
+@@ -317,6 +324,10 @@ sub generate_file_blockdev {
+         my $vtype = (PVE::Storage::parse_volname($storecfg, $drive->{file}))[0];
+         die "$drive_id: explicit media parameter is required for iso images\n"
+             if !defined($drive->{media}) && defined($vtype) && $vtype eq 'iso';
++        die "$drive_id: floppy images can only be used with floppy drives\n"
++            if defined($vtype)
++            && $vtype eq 'floppy'
++            && !PVE::QemuServer::Drive::drive_is_floppy($drive);
+ 
+         my $storage_opts = { hints => {} };
+         $storage_opts->{hints}->{'efi-disk'} = 1 if $drive->{interface} eq 'efidisk';
+diff --git c/src/PVE/QemuServer/Drive.pm i/src/PVE/QemuServer/Drive.pm
+index b80b7dbb..6e548dbf 100644
+--- c/src/PVE/QemuServer/Drive.pm
++++ i/src/PVE/QemuServer/Drive.pm
+@@ -23,6 +23,7 @@ our @EXPORT_OK = qw(
+     checked_volume_format
+     drive_is_cloudinit
+     drive_is_cdrom
++    drive_is_floppy
+     parse_drive
+     print_drive
+     storage_allows_io_uring_default
+@@ -155,6 +156,7 @@ my $MAX_IDE_DISKS = 4;
+ my $MAX_SCSI_DISKS = 31;
+ my $MAX_VIRTIO_DISKS = 16;
+ our $MAX_SATA_DISKS = 6;
++our $MAX_FLOPPY_DRIVES = 2;
+ our $MAX_UNUSED_DISKS = 256;
+ our $NEW_DISK_RE = qr!^(([^/:\s]+):)?(\d+(\.\d+)?)$!;
+ 
+@@ -603,6 +605,41 @@ my $tpmstate_desc = {
+ };
+ use constant TPMSTATE_DISK_SIZE => 4 * 1024 * 1024;
+ 
++my $floppy_fmt = {
++    volume => { alias => 'file' },
++    file => {
++        type => 'string',
++        format => 'pve-volume-id-or-qm-path',
++        default_key => 1,
++        format_description => 'volume',
++        description => "The floppy image volume.",
++    },
++    media => {
++        type => 'string',
++        enum => [qw(floppy)],
++        description => "The drive's media type.",
++        default => 'floppy',
++        optional => 1,
++    },
++    format => get_standard_option('pve-qm-image-format'),
++    size => {
++        type => 'string',
++        format => 'disk-size',
++        format_description => 'DiskSize',
++        description => "Disk size. This is purely informational and has no effect.",
++        optional => 1,
++    },
++    %readonly_fmt,
++};
++my $floppydesc = {
++    optional => 1,
++    type => 'string',
++    format => $floppy_fmt,
++    description => "Use volume as floppy disk image (n is 0 to "
++        . ($MAX_FLOPPY_DRIVES - 1) . ").",
++};
++PVE::JSONSchema::register_standard_option("pve-qm-floppy", $floppydesc);
++
+ my $alldrive_fmt = {
+     %drivedesc_base,
+     %iothread_fmt,
+@@ -710,6 +747,12 @@ $drivedesc_hash_with_alloc->{efidisk0} = $desc_with_alloc->('efidisk', $efidisk_
+ $drivedesc_hash->{tpmstate0} = $tpmstate_desc;
+ $drivedesc_hash_with_alloc->{tpmstate0} = $desc_with_alloc->('tpmstate', $tpmstate_desc);
+ 
++for (my $i = 0; $i < $MAX_FLOPPY_DRIVES; $i++) {
++    # floppies only reference existing volumes, so there is no allocation variant
++    $drivedesc_hash->{"floppy$i"} = $floppydesc;
++    $drivedesc_hash_with_alloc->{"floppy$i"} = $floppydesc;
++}
++
+ for (my $i = 0; $i < $MAX_UNUSED_DISKS; $i++) {
+     $drivedesc_hash->{"unused$i"} = $unuseddesc;
+     $drivedesc_hash_with_alloc->{"unused$i"} = $desc_with_alloc->('unused', $unuseddesc);
+@@ -728,6 +771,7 @@ sub valid_drive_names {
+         (map { "sata$_" } (0 .. ($MAX_SATA_DISKS - 1))),
+         'efidisk0',
+         'tpmstate0',
++        (map { "floppy$_" } (0 .. ($MAX_FLOPPY_DRIVES - 1))),
+     );
+ }
+ 
+@@ -758,11 +802,21 @@ sub drive_is_cloudinit {
+     return $drive->{file} =~ m@[:/](?:vm-\d+-)?cloudinit(?:\.$QEMU_FORMAT_RE)?$@;
+ }
+ 
++sub drive_is_floppy {
++    my ($drive) = @_;
++
++    return $drive && $drive->{interface} && ($drive->{interface} eq 'floppy');
++}
++
+ sub drive_is_cdrom {
+     my ($drive, $exclude_cloudinit) = @_;
+ 
+     return 0 if $exclude_cloudinit && drive_is_cloudinit($drive);
+ 
++    # floppies share the removable reference-media semantics of cdroms
++    # (not backed up, not snapshotted, not copied on clone, never freed)
++    return 1 if drive_is_floppy($drive);
++
+     return $drive && $drive->{media} && ($drive->{media} eq 'cdrom');
+ }
+ 
+@@ -847,7 +901,13 @@ sub parse_drive {
  
      if ($res->{media} && ($res->{media} eq 'cdrom')) {
          return if $res->{snapshot} || $res->{format};
 -        return if $res->{interface} eq 'virtio';
 +        #return if $res->{interface} eq 'virtio'; // I have no idea why this was disabled in the first place, so I've basically fucked around and later I might find out :)
++    }
++
++    if ($res->{interface} eq 'floppy') {
++        # floppies are always backed by an image file or volume, host cdrom
++        # passthrough makes no sense here
++        return if $res->{file} eq 'cdrom';
      }
  
      if (my $size = $res->{size}) {
-diff --git a/src/PVE/QemuServer/DriveDevice.pm b/src/PVE/QemuServer/DriveDevice.pm
-index 37b611f0..40c7841f 100644
---- a/src/PVE/QemuServer/DriveDevice.pm
-+++ b/src/PVE/QemuServer/DriveDevice.pm
+diff --git c/src/PVE/QemuServer/DriveDevice.pm i/src/PVE/QemuServer/DriveDevice.pm
+index 37b611f0..4fc7cd5c 100644
+--- c/src/PVE/QemuServer/DriveDevice.pm
++++ i/src/PVE/QemuServer/DriveDevice.pm
 @@ -78,7 +78,9 @@ sub print_drivedevice_full {
          my $device_type =
              PVE::QemuServer::Drive::get_scsi_device_type($drive, $storecfg, $machine_version);
@@ -341,7 +612,24 @@ index 37b611f0..40c7841f 100644
              $device = "scsi-$device_type,bus=$controller_prefix$controller.0,scsi-id=$unit";
          } else {
              $device = "scsi-$device_type,bus=$controller_prefix$controller.0,channel=0,scsi-id=0"
-@@ -192,6 +194,10 @@ sub print_drivedevice_full {
+@@ -165,6 +167,16 @@ sub print_drivedevice_full {
+             }
+         }
+         $device .= ",wwn=$drive->{wwn}" if $drive->{wwn};
++    } elsif ($drive->{interface} eq 'floppy') {
++        # attaches to the isa-fdc controller (onboard on i440fx, added
++        # explicitly for q35 in config_to_command)
++        $device = "floppy,unit=$drive->{index}";
++        # for the switch to -blockdev, there is no blockdev for 'none'
++        if (!min_version($machine_version, 10, 0) || $drive->{file} ne 'none') {
++            $device .= ",drive=drive-$drive_id";
++        }
++        $device .= ",id=$drive_id";
++        $has_write_cache = 0;
+     } elsif ($drive->{interface} eq 'usb') {
+         die "implement me";
+         #  -device ide-drive,bus=ide.1,unit=0,drive=drive-ide0-1-0,id=ide0-1-0
+@@ -192,6 +204,10 @@ sub print_drivedevice_full {
          }
      }
  
@@ -352,10 +640,10 @@ index 37b611f0..40c7841f 100644
      return $device;
  }
  
-diff --git a/src/PVE/QemuServer/Helpers.pm b/src/PVE/QemuServer/Helpers.pm
+diff --git c/src/PVE/QemuServer/Helpers.pm i/src/PVE/QemuServer/Helpers.pm
 index dd17eef5..5f376d5c 100644
---- a/src/PVE/QemuServer/Helpers.pm
-+++ b/src/PVE/QemuServer/Helpers.pm
+--- c/src/PVE/QemuServer/Helpers.pm
++++ i/src/PVE/QemuServer/Helpers.pm
 @@ -26,6 +26,8 @@ our @EXPORT_OK = qw(
  my $nodename = PVE::INotify::nodename();
  
@@ -394,11 +682,11 @@ index dd17eef5..5f376d5c 100644
  
      my $cachedmtime = $kvm_mtime->{$binary} // -1;
      return $kvm_user_version->{$binary}
-diff --git a/src/PVE/QemuServer/Machine.pm b/src/PVE/QemuServer/Machine.pm
-index 37b272c6..d24c615a 100644
---- a/src/PVE/QemuServer/Machine.pm
-+++ b/src/PVE/QemuServer/Machine.pm
-@@ -57,7 +57,7 @@ my $machine_fmt = {
+diff --git c/src/PVE/QemuServer/Machine.pm i/src/PVE/QemuServer/Machine.pm
+index 35161d1f..64a3a3cf 100644
+--- c/src/PVE/QemuServer/Machine.pm
++++ i/src/PVE/QemuServer/Machine.pm
+@@ -58,7 +58,7 @@ my $machine_fmt = {
          description => "Specifies the QEMU machine type.",
          type => 'string',
          pattern =>
@@ -407,7 +695,7 @@ index 37b272c6..d24c615a 100644
          maxLength => 40,
          format_description => 'machine type',
          optional => 1,
-@@ -123,6 +123,8 @@ sub print_machine {
+@@ -124,6 +124,8 @@ sub print_machine {
  my $default_machines = {
      x86_64 => 'pc',
      aarch64 => 'virt',
@@ -416,7 +704,7 @@ index 37b272c6..d24c615a 100644
  };
  
  sub default_machine_for_arch {
-@@ -166,6 +168,7 @@ my sub machine_base_type {
+@@ -167,6 +169,7 @@ my sub machine_base_type {
      return 'q35' if $machine_type =~ m/q35/;
      return 'i440fx' if $machine_type =~ m/^pc/;
      return 'virt' if $machine_type =~ m/^virt/;
@@ -424,7 +712,7 @@ index 37b272c6..d24c615a 100644
  
      die "unable to determine machine base type '$machine_type'\n";
  }
-@@ -321,18 +324,15 @@ sub get_machine_pve_revisions {
+@@ -322,18 +325,15 @@ sub get_machine_pve_revisions {
          return $PVE_MACHINE_VERSION->{$1};
      }
  
@@ -447,7 +735,7 @@ index 37b272c6..d24c615a 100644
  }
  
  sub can_run_pve_machine_version {
-@@ -494,6 +494,7 @@ sub get_power_state_flags {
+@@ -495,6 +495,7 @@ sub get_power_state_flags {
  
      my $options = [];
  
@@ -455,7 +743,7 @@ index 37b272c6..d24c615a 100644
      # they're enabled by default in QEMU, so only add the flags to disable them
      if (!$s3) {
          push $options->@*, '-global', "${object}.disable_s3=1";
-@@ -501,6 +502,7 @@ sub get_power_state_flags {
+@@ -502,6 +503,7 @@ sub get_power_state_flags {
      if (!$s4) {
          push $options->@*, '-global', "${object}.disable_s4=1";
      }
@@ -463,10 +751,10 @@ index 37b272c6..d24c615a 100644
  
      if (scalar($options->@*)) {
          return $options;
-diff --git a/src/PVE/QemuServer/Network.pm b/src/PVE/QemuServer/Network.pm
+diff --git c/src/PVE/QemuServer/Network.pm i/src/PVE/QemuServer/Network.pm
 index 11bebdec..a345c463 100644
---- a/src/PVE/QemuServer/Network.pm
-+++ b/src/PVE/QemuServer/Network.pm
+--- c/src/PVE/QemuServer/Network.pm
++++ i/src/PVE/QemuServer/Network.pm
 @@ -28,6 +28,8 @@ my $nic_model_list = [
      'rtl8139',
      'virtio',
@@ -476,10 +764,10 @@ index 11bebdec..a345c463 100644
  ];
  
  my $net_fmt_bridge_descr = <<__EOD__;
-diff --git a/src/PVE/QemuServer/PCI.pm b/src/PVE/QemuServer/PCI.pm
+diff --git c/src/PVE/QemuServer/PCI.pm i/src/PVE/QemuServer/PCI.pm
 index 0b67943c..e276ad81 100644
---- a/src/PVE/QemuServer/PCI.pm
-+++ b/src/PVE/QemuServer/PCI.pm
+--- c/src/PVE/QemuServer/PCI.pm
++++ i/src/PVE/QemuServer/PCI.pm
 @@ -299,6 +299,11 @@ sub print_pci_addr {
  
      my $res = '';
@@ -492,10 +780,10 @@ index 0b67943c..e276ad81 100644
      my $map = get_pci_addr_map();
      if (my $d = $get_addr_mapping_from_id->($map, $id)) {
          # Using same bus slots on all HW, so we need to check special cases here. For aarch64, the
-diff --git a/src/PVE/QemuServer/USB.pm b/src/PVE/QemuServer/USB.pm
+diff --git c/src/PVE/QemuServer/USB.pm i/src/PVE/QemuServer/USB.pm
 index c9408a42..3450c27c 100644
---- a/src/PVE/QemuServer/USB.pm
-+++ b/src/PVE/QemuServer/USB.pm
+--- c/src/PVE/QemuServer/USB.pm
++++ i/src/PVE/QemuServer/USB.pm
 @@ -136,6 +136,8 @@ sub get_usb_controllers {
      if ($arch eq 'aarch64') {
          $pciaddr = print_pci_addr('ehci', $bridges, $arch);
@@ -514,3 +802,50 @@ index c9408a42..3450c27c 100644
          # include usb device config if still on x86 before-xhci machines and if USB 3 is not used
          push @$devices, '-readconfig', '/usr/share/qemu-server/pve-usb.cfg';
      }
+diff --git c/src/test/cfg2cmd/floppy.conf i/src/test/cfg2cmd/floppy.conf
+new file mode 100644
+index 00000000..d606dfbf
+--- /dev/null
++++ i/src/test/cfg2cmd/floppy.conf
+@@ -0,0 +1,11 @@
++# TEST: i440fx VM with a boot floppy and a second read-only floppy (onboard fdc, no isa-fdc)
++boot: order=floppy0;scsi0
++cores: 2
++floppy0: local:floppy/dos622-boot.img,size=1440K
++floppy1: local:floppy/drivers.img,ro=1,size=1440K
++memory: 512
++ostype: other
++scsi0: local:100/vm-100-disk-2.qcow2,size=10G
++scsihw: virtio-scsi-pci
++smbios1: uuid=3dd750ce-d910-44d0-9493-525c0be4e687
++vmgenid: 54d1c06c-8f5b-440f-b5b2-6eab1380e13d
+diff --git c/src/test/cfg2cmd/q35-floppy.conf i/src/test/cfg2cmd/q35-floppy.conf
+new file mode 100644
+index 00000000..b6378e36
+--- /dev/null
++++ i/src/test/cfg2cmd/q35-floppy.conf
+@@ -0,0 +1,12 @@
++# TEST: q35 VM with a floppy image and an empty floppy drive (explicit isa-fdc controller)
++boot: order=floppy0;scsi0
++cores: 2
++floppy0: local:floppy/dos622-boot.img,size=1440K
++floppy1: none
++machine: q35
++memory: 512
++ostype: other
++scsi0: local:100/vm-100-disk-2.qcow2,size=10G
++scsihw: virtio-scsi-pci
++smbios1: uuid=3dd750ce-d910-44d0-9493-525c0be4e687
++vmgenid: 54d1c06c-8f5b-440f-b5b2-6eab1380e13d
+diff --git c/src/test/run_config2command_tests.pl i/src/test/run_config2command_tests.pl
+index 47250c67..a2f03f37 100755
+--- c/src/test/run_config2command_tests.pl
++++ i/src/test/run_config2command_tests.pl
+@@ -31,6 +31,7 @@ my $base_env = {
+                 content => {
+                     images => 1,
+                     iso => 1,
++                    floppy => 1,
+                 },
+                 path => '/var/lib/vz',
+                 type => 'dir',


### PR DESCRIPTION
## Summary

Implements the long-standing floppy TODO (README/TODO.md) across all layers:

- **pve-storage (new sixth submodule, `hwinther/pve-storage` @ 9.1.7)**: new `floppy` content type stored in `template/floppy/` next to `template/iso/`. Volnames `floppy/<name>` with `.img`/`.ima`/`.vfd` extensions, listing (`?content=floppy`), upload + download-from-URL, dir-based plugins (dir/NFS/CIFS/BTRFS/CephFS), auto-created subdir, and upstream test extensions. Ships as a `libpve-storage-perl` `+wsh` deb.
- **qemu-server**: `floppy0`/`floppy1` config keys (new `floppy` drive interface, max 2). `-blockdev` + `-device floppy,unit=N` emission, explicit `isa-fdc` on q35 only (i440fx has an onboard FDC), boot-from-floppy via boot order and legacy letter `a`, and **live media swap** on running VMs via the existing cdrom `change_medium` machinery. Floppies get removable-reference-media semantics via a `drive_is_cdrom()` overload (excluded from backup/snapshot/clone/deallocate); writable by default with `ro=1` support. Includes `cfg2cmd` test configs for both machine types (goldens generate on first dev-host test run).
- **pve-manager**: FloppySelector + FloppyEdit dialog, Hardware panel rows + Add menu entry (gated on `VM.Config.CDROM`), Floppy Images storage tab with upload, content-type registration, boot-order UI support, `template/floppy` install dir.
- **Docs**: fills in the `reference/floppy.md` placeholder; README/TODO updated.
- **CI**: `sync-pve-storage.yml`, check-patches loop, patch-triggered deb build + failure-PR wiring, build-deb dispatch choice, Makefile targets, `repo.Dockerfile` stage.

All three regenerated patches verified to apply cleanly against their pristine gitlink commits.

## Post-merge sequence

1. Dispatch `build-deb.yml` with `package=pve-storage` once to seed the GHCR image and generate `pve-storage.changelog.patch` (until then, `repo-update` will fail on the missing `pve-storage:latest` image).
2. On the dev host: `make dev-links`, run `src/test/run_config2command_tests.pl` (generates the floppy golden files), and smoke-test: enable Floppy content on `local`, upload an image, add a floppy drive, boot DOS on i440fx and q35 (`qm showcmd` should show `isa-fdc` only on q35), swap media on a running VM, verify vzdump skips the floppy volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125DUy6Hbw2aPAbhKgHvtEN